### PR TITLE
Add gulp to package.json scripts for ease of CI.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Hugo theme made for documentation",
   "main": "gulpfile.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "gulp": "gulp"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When using themes through git submodule some steps need to be ran in CI. One of these being the `gulp default` run. By adding this to the package.json CI setups for Hugo can use `npm i && npm run gulp default` instead of having to install gulp separately.