### PR TITLE
Relative URL resolution for fonts

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,14 +6,14 @@
 
 <link rel="icon" href="{{ "favicon/favicon-32x32.png" | relURL }}" type="image/x-icon">
 
-<link rel="preload" as="font" href="/fonts/Metropolis.woff2" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" as="font" href="/fonts/LiberationSans.woff2" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" as="font" href="/fonts/LiberationSans-Bold.woff2" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" as="font" href="/fonts/LiberationSans-BoldItalic.woff2" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" as="font" href="/fonts/LiberationSans-Italic.woff2" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" as="font" href="/fonts/LiberationMono.woff2" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" as="font" href="/fonts/DroidSans.woff2" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" as="font" href="/fonts/GeekdocIcons.woff2" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" as="font" href="{{ "/fonts/Metropolis.woff2" | relURL }}" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" as="font" href="{{ "/fonts/LiberationSans.woff2" | relURL }}" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" as="font" href="{{ "/fonts/LiberationSans-Bold.woff2" | relURL }}" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" as="font" href="{{ "/fonts/LiberationSans-BoldItalic.woff2" | relURL }}" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" as="font" href="{{ "/fonts/LiberationSans-Italic.woff2" | relURL }}" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" as="font" href="{{ "/fonts/LiberationMono.woff2" | relURL }}" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" as="font" href="{{ "/fonts/DroidSans.woff2" | relURL }}" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" as="font" href="{{ "/fonts/GeekdocIcons.woff2" | relURL }}" type="font/woff2" crossorigin="anonymous">
 
 <link rel="preload" href="{{ "main.min.css" | relURL }}" as="style">
 <link rel="stylesheet" href="{{ "main.min.css" | relURL }}" media="screen">


### PR DESCRIPTION
When using baseURL in order to place the site into a subdirectory, fonts are not found because they are not placed in the root directory. Function relURL should also be used for fonts path resolution.