### PR TITLE
Allow description text in toc-tree items

### DIFF
--- a/exampleSite/content/usage/configuration.md
+++ b/exampleSite/content/usage/configuration.md
@@ -170,6 +170,9 @@ weight = 10
 # Set how many table of contents levels to be showed on page.
 geekdocToC = 3
 
+# Set a description for the current page. This will be shown in toc-trees objects
+GeekdocDescription =
+
 # Show a breadcrumb navigation bar at the top of each docs page.
 geekdocBreadcrumb = false
 
@@ -206,6 +209,9 @@ weight: 10
 
 # Set how many table of contents levels to be showed on page.
 geekdocToC: 3
+
+# Set a description for the current page. This will be shown in toc-trees objects
+GeekdocDescription:
 
 # Show a breadcrumb navigation bar at the top of each docs page.
 geekdocBreadcrumb: false

--- a/layouts/shortcodes/toc-tree.html
+++ b/layouts/shortcodes/toc-tree.html
@@ -15,10 +15,10 @@
       <li>
       {{ if or .Content .Params.geekdocFlatSection }}
         <span>
-          <a href="{{ .RelPermalink }}" class="gdoc-toc__entry">{{ partial "title" . }}</a>
+          <a href="{{ .RelPermalink }}" class="gdoc-toc__entry">{{ partial "title" . }}{{ with .Params.GeekdocDescription }}:</a> {{ . }}{{ else }}</a>{{ end }}
         </span>
       {{ else }}
-        <span>{{ partial "title" . }}</span>
+        <span>{{ partial "title" . }}{{ with .Params.GeekdocDescription }}: {{ . }}{{ end }}</span>
       {{ end }}
 
       {{ $numberOfPages := (add (len .Pages) (len .Sections)) }}


### PR DESCRIPTION
If an item of a toc-tree has a description flag, append it with a colon as prefix.

For instance:

```
# content/test/_index.md
...
{{< toc-tree >}}
```

```
# content/test/item.md
- - - 
title: Item
description: Item description
- - - 
```

Will be shown as follows:
![image](https://user-images.githubusercontent.com/29432139/98601787-d2864b80-22df-11eb-8ee1-cf2501a07c31.png)
