### PR TITLE
Allow geekdocHiddenInPage as Page parameter

### DIFF
--- a/exampleSite/content/usage/configuration.md
+++ b/exampleSite/content/usage/configuration.md
@@ -193,6 +193,10 @@ geekdocFlatSection = true
 # Set true to hide page or section from side menu (file-tree menu only)
 geekdocHidden = true
 
+# Set false to show this page as a file-tree menu entry when you want it to be hidden in the sidebar
+# NOTE: Only applies when geekdocHidden=true
+geekdocHiddenTocTree = true
+
 # Add an anchor link to headlines
 geekdocAnchor = true
 ```
@@ -232,6 +236,10 @@ geekdocFlatSection: true
 
 # Set true to hide page or section from side menu (file-tree menu only)
 geekdocHidden: true
+
+# Set false to show this page as a file-tree menu entry when you want it to be hidden in the sidebar
+# NOTE: Only applies when geekdocHidden=true
+geekdocHiddenTocTree: true
 
 # Add an anchor link to headlines
 geekdocAnchor: true

--- a/layouts/shortcodes/toc-tree.html
+++ b/layouts/shortcodes/toc-tree.html
@@ -11,7 +11,7 @@
   <ul>
     {{ range .sect.GroupBy "Weight" }}
       {{ range .ByTitle }}
-      {{ if not .Params.geekdocHidden }}
+      {{ if or (not .Params.geekdocHidden) (not (default true .Params.geekdocHiddenTocTree)) }}
       <li>
       {{ if or .Content .Params.geekdocFlatSection }}
         <span>


### PR DESCRIPTION
I want to display a toc-tree in the page but not in the side bar. `geekdocHiddenInPage` param allows us to do that.

For instance:
```
# content/group/extra1.md
---
name: Extra1
weight: ...
geekDocHidden: true
geekDocHiddenInPage: false
---
```
```
# content/group/_index.md
## Table of contents
{{< toc-tree >}}
```

With this feature, you will see Extra1 in the page but not in the sidebar.

**Behaviour:**
`geekDocHidden=true` takes always precedence. `geekDocHiddenInPage` applies only when `geekDocHidden=false`  and the default value is `geekDocHiddenInPage=true` to be used only if you want to use.