### PR TITLE
Allow geekdocSearchShowParent

### DIFF
--- a/assets/js/search-data.js
+++ b/assets/js/search-data.js
@@ -10,7 +10,7 @@
   indexCfg.doc = {
     id: 'id',
     field: ['title', 'content'],
-    store: ['title', 'href'],
+    store: ['title', 'href', 'parent'],
   };
 
   const index = FlexSearch.create(indexCfg);
@@ -21,6 +21,7 @@
     'id': {{ $index }},
     'href': '{{ $page.RelPermalink }}',
     'title': {{ (partial "title" $page) | jsonify }},
+    'parent': {{ with $page.Parent }}{{ (partial "title" .) | jsonify }}{{ else }}''{{ end }},
     'content': {{ $page.Plain | jsonify }}
   });
   {{- end -}}

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -46,7 +46,12 @@
             a = li.appendChild(document.createElement('a'));
 
       a.href = page.href;
+
+      {{ if .Site.Params.GeekdocSearchShowParent }}
+      a.textContent = page.parent ? page.parent + ' / ' + page.title : page.title;
+      {{ else }}
       a.textContent = page.title;
+      {{ end }}
 
       results.appendChild(li);
       results.classList.add("DUMMY");

--- a/exampleSite/content/usage/configuration.md
+++ b/exampleSite/content/usage/configuration.md
@@ -62,6 +62,11 @@ enableGitInfo = true
   # Index is built on the fly and might slowdown your website.
   geekdocSearch = false
 
+  # (Optional, default false) Display search results with the parent folder as prefix. This
+  # option allows you to distinguish between files with the same name in different folders.
+  # NOTE: This parameter only applies when geekdocSearch=true
+  GeekdocSearchShowParent = true
+
   # (Optional, default none) Add a link to your Legal Notice page to the site footer.
   # It can be either a remote url or a local file path relative to your content directory.
   geekdocLegalNotice = "https://blog.example.com/legal"
@@ -136,6 +141,11 @@ params:
   # (Optional, default true) Enables search function with flexsearch.
   # Index is built on the fly and might slowdown your website.
   geekdocSearch: false
+
+  # (Optional, default false) Display search results with the parent folder as prefix. This
+  # option allows you to distinguish between files with the same name in different folders.
+  # NOTE: This parameter only applies when geekdocSearch=true
+  GeekdocSearchShowParent: true
 
   # (Optional, default none) Add a link to your Legal Notice page to the site footer.
   # It can be either a remote url or a local file path relative to your content directory.


### PR DESCRIPTION
Titles in search results have not context. For example, if I have multiple "Getting Started" pages, all the results are going to be the same. This PR is to be able to give more context to search results:

If you activate this behaviour in your config file:
```
# config.yml
...
params:
  ...
  geekdocSearch: true
  geekdocSearchShowParent: true
```

Then, first parent is shown as prefix in search results:
* `geekdocSearchShowParent: false` (default and current approach):
![image](https://user-images.githubusercontent.com/29432139/98716330-afb17100-238b-11eb-885d-cfbe3cb6c975.png)

* `geekdocSearchShowParent: true`:
![image](https://user-images.githubusercontent.com/29432139/98717171-079ca780-238d-11eb-9581-5f21bd087fa1.png)
