### PR TITLE
fix: set line-height in normalized h1 to avoid overlapping

### DIFF
--- a/src/sass/_defaults.scss
+++ b/src/sass/_defaults.scss
@@ -31,9 +31,6 @@ $color-link-footer: rgba(255, 163, 30, 1) !default;
 
 $color-code: rgba($gray-200, 0.5) !default;
 
-$header-font-size: 2em;
-$header-font-size-small: 1.5em;
-
 $body-background: white !default;
 $body-font-color: $gray-800 !default;
 $body-font-weight: normal !default;

--- a/src/sass/_normalize.css
+++ b/src/sass/_normalize.css
@@ -40,6 +40,7 @@ main {
 h1 {
   font-size: 2em;
   margin: 0.67em 0;
+  line-height: 1.2em;
 }
 
 /* Grouping content


### PR DESCRIPTION
Fixes https://github.com/thegeeklab/hugo-geekdoc/issues/57