### PR TITLE
move logo size to _base.scss

### DIFF
--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -8,7 +8,7 @@
         {{ end }}
         <a class="gdoc-header__link" href="{{ .Root.Site.BaseURL }}">
             <span class="gdoc-brand flex align-center">
-                <img class="gdoc-brand__img" src="{{ (default "brand.svg" .Root.Site.Params.GeekdocLogo) | relURL }}" alt="" width=38 height=38>
+                <img class="gdoc-brand__img" src="{{ (default "brand.svg" .Root.Site.Params.GeekdocLogo) | relURL }}" alt="">
                 {{ .Root.Site.Title }}
             </span>
         </a>

--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -117,6 +117,8 @@ img {
 
   &__img {
     margin-right: $padding-16;
+    width: 38px;
+    height: 38px;
   }
 }
 


### PR DESCRIPTION
If you want add another logo it could be useful to change the size of it
with a custom css overwrite. With the old version this isn't possible
because the size defined in the img tag is always more significant. This
commit removes the height and width from the img tag and moves it to the
_base.scss file.