### PR TITLE
fix: rework site header for better title and decription handling

### DIFF
--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Documentation
+description: Geekdoc is a simple Hugo theme for documentations. It is intentionally designed as a fast and lean theme and may not fit the requirements of complex projects. If a more feature-complete theme is required there are a lot of got alternatives out there.
 ---
 
 <!-- markdownlint-capture -->
@@ -13,7 +14,7 @@ title: Documentation
 
 <!-- markdownlint-restore -->
 
-Geekdoc is a simple Hugo theme for documentations. It is intentionally designed as a fast and lean theme and may not fit the requirements of complex projects. If a more feature-complete theme is required there are a lot of got alternatives out there. You can find a demo and the full documentation at [https://geekdocs.de](https://geekdocs.de).
+Geekdoc is a simple Hugo theme for documentations. It is intentionally designed as a fast and lean theme and may not fit the requirements of complex projects. If a more feature-complete theme is required there are a lot of got alternatives out there.
 
 ## Features
 

--- a/exampleSite/content/usage/getting-started.md
+++ b/exampleSite/content/usage/getting-started.md
@@ -5,6 +5,8 @@ weight: -20
 
 This page tells you how to get started with the Geekdoc theme, including installation and basic configuration.
 
+<!--more-->
+
 {{< toc >}}
 
 ## Install requirements

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -2,7 +2,11 @@
 <html lang="{{ .Site.Language.Lang }}">
 
 <head>
-    {{ partial "head" . }}
+    {{ partial "head/meta" . }}
+    <title>Lost? Don't worry</title>
+
+    {{ partial "head/favicons" . }}
+    {{ partial "head/others" . }}
 </head>
 
 <body>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,7 +2,11 @@
 <html lang="{{ .Site.Language.Lang }}">
 
 <head>
-    {{ partial "head" . }}
+    {{ partial "head/meta" . }}
+    <title>{{ if not (eq .Kind "home") }}{{ partial "title" . }} | {{ end }}{{ .Site.Title }}</title>
+
+    {{ partial "head/favicons" . }}
+    {{ partial "head/others" . }}
 </head>
 
 <body itemscope itemtype="https://schema.org/WebPage">

--- a/layouts/partials/head/favicons.html
+++ b/layouts/partials/head/favicons.html
@@ -1,0 +1,1 @@
+<link rel="icon" href="{{ "favicon/favicon-32x32.png" | relURL }}" type="image/x-icon">

--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -1,0 +1,12 @@
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+{{ $description := default (default .Site.Title .Site.Params.description) (default .Summary .Description) }}
+{{ $keywords := default .Site.Params.Keywords .Keywords }}
+
+{{ with $description }}
+    <meta name="description" content="{{ . }}">
+{{ end }}
+{{ with $keywords }}
+    <meta name="keywords" content="{{ delimit . "," }}">
+{{ end }}

--- a/layouts/partials/head/others.html
+++ b/layouts/partials/head/others.html
@@ -1,9 +1,3 @@
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="description" content="{{ partial "title" . }}">
-
-<title>{{ partial "title" . }} | {{ .Site.Title -}}</title>
-
 <link rel="icon" href="{{ "favicon/favicon-32x32.png" | relURL }}" type="image/x-icon">
 
 <link rel="preload" as="font" href="{{ "fonts/Metropolis.woff2" | relURL }}" type="font/woff2" crossorigin="anonymous">


### PR DESCRIPTION
Fixes: #96 

Description:
- Title will use format `<Page Title> | <Site Name>` except error and home page
- Description will use (first found):
  - .Description
  - [.Summary](https://gohugo.io/content-management/summaries/)
  - .Site.Params.description
  - .Site.Title