### PR TITLE
feat: add mathjax support

### DIFF
--- a/layouts/partials/mathjax.html
+++ b/layouts/partials/mathjax.html
@@ -1,0 +1,21 @@
+{{ if .Params.math }}
+<script>
+  MathJax = {
+    tex: {
+      inlineMath: [["$", "$"]],
+    },
+    displayMath: [
+      ["$$", "$$"],
+      ["\[\[", "\]\]"],
+    ],
+    svg: {
+      fontCache: "global",
+    },
+  };
+</script>
+<script
+  id="MathJax-script"
+  async
+  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
+></script>
+{{ end }}

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -46,3 +46,5 @@
     </div>
     {{ end }}
 </div>
+
+{{ partial "mathjax.html" . }}


### PR DESCRIPTION
Added MathJax support for equation typesetting with latex syntax. 😺 

![test-mathjax](https://user-images.githubusercontent.com/73936909/122928749-bdf15200-d39c-11eb-9a39-4ed505c044f8.jpg)
