### PR TITLE
feat: collapse every section

### DIFF
--- a/exampleSite/content/usage/configuration.md
+++ b/exampleSite/content/usage/configuration.md
@@ -134,6 +134,10 @@ params:
   # See also https://geekdocs.de/usage/menus/#bundle-menu
   geekdocMenuBundle: true
 
+  # (Optional, default false) Collapse all menu entries, can not be overwritten
+  # per page if enabled. Can be enabled per page via `geekdocCollapseSection`
+  GeekdocCollapseAllSections: true
+
   # (Optional, default true) Show page navigation links at the bottom of each
   # docs page (bundle menu only).
   geekdocNextPrev: false

--- a/exampleSite/content/usage/configuration.md
+++ b/exampleSite/content/usage/configuration.md
@@ -136,7 +136,7 @@ params:
 
   # (Optional, default false) Collapse all menu entries, can not be overwritten
   # per page if enabled. Can be enabled per page via `geekdocCollapseSection`
-  GeekdocCollapseAllSections: true
+  geekdocCollapseAllSections: true
 
   # (Optional, default true) Show page navigation links at the bottom of each
   # docs page (bundle menu only).

--- a/layouts/partials/menu-bundle.html
+++ b/layouts/partials/menu-bundle.html
@@ -23,8 +23,9 @@
             {{ $isAncestor := $this.IsAncestor $current }}
             {{ $id := substr (sha1 $this.Permalink) 0 8 }}
             {{ $hasCollapse := and $this.Params.GeekdocCollapseSection (isset . "sub") }}
+            {{ $doCollapse := or $hasCollapse (default false .Site.Params.GeekdocCollapseAllSections) }}
 
-            {{ if $hasCollapse }}
+            {{ if $doCollapse }}
             <input type="checkbox" id="{{ printf "navtree-%s" $id }}" class="gdoc-nav__toggle" {{ if or $isCurrent $isAncestor }}checked{{ end }}>
             <label for="{{ printf "navtree-%s" $id }}" class="flex justify-between">
             {{ end }}
@@ -35,7 +36,7 @@
                     {{ .name }}
                 </a>
             </span>
-            {{ if $hasCollapse }}
+            {{ if $doCollapse }}
             <svg class="icon gdoc_keyborad_arrow_left"><use xlink:href="#gdoc_keyborad_arrow_left"></use></svg>
             <svg class="icon gdoc_keyborad_arrow_down hidden"><use xlink:href="#gdoc_keyborad_arrow_down"></use></svg>
             </label>

--- a/layouts/partials/menu-bundle.html
+++ b/layouts/partials/menu-bundle.html
@@ -22,8 +22,7 @@
             {{ $isCurrent := eq $current $this }}
             {{ $isAncestor := $this.IsAncestor $current }}
             {{ $id := substr (sha1 $this.Permalink) 0 8 }}
-            {{ $hasCollapse := and $this.Params.GeekdocCollapseSection (isset . "sub") }}
-            {{ $doCollapse := or $hasCollapse (default false .Site.Params.GeekdocCollapseAllSections) }}
+            {{ $doCollapse := and (isset . "sub") (or $this.Params.GeekdocCollapseSection (default false .Site.Params.GeekdocCollapseAllSections)) }}
 
             {{ if $doCollapse }}
             <input type="checkbox" id="{{ printf "navtree-%s" $id }}" class="gdoc-nav__toggle" {{ if or $isCurrent $isAncestor }}checked{{ end }}>

--- a/layouts/partials/menu-filetree.html
+++ b/layouts/partials/menu-filetree.html
@@ -16,9 +16,10 @@
             {{ $isAncestor := .IsAncestor $current }}
             {{ $id := substr (sha1 .Permalink) 0 8 }}
             {{ $hasCollapse := and $isParent .Params.GeekdocCollapseSection }}
+            {{ $doCollapse := or $hasCollapse (default false .Site.Params.GeekdocCollapseAllSections) }}
 
             <li>
-            {{ if $hasCollapse }}
+            {{ if $doCollapse }}
             <input type="checkbox" id="{{ printf "navtree-%s" $id }}" class="gdoc-nav__toggle" {{ if or $isCurrent $isAncestor }}checked{{ end }}>
             <label for="{{ printf "navtree-%s" $id }}" class="flex justify-between">
             {{ end }}
@@ -31,7 +32,7 @@
             {{ else }}
                 <span class="flex">{{ partial "title" . }}</span>
             {{ end }}
-            {{ if $hasCollapse }}
+            {{ if $doCollapse }}
                 <svg class="icon gdoc_keyborad_arrow_left"><use xlink:href="#gdoc_keyborad_arrow_left"></use></svg>
                 <svg class="icon gdoc_keyborad_arrow_down hidden"><use xlink:href="#gdoc_keyborad_arrow_down"></use></svg>
             </label>

--- a/layouts/partials/menu-filetree.html
+++ b/layouts/partials/menu-filetree.html
@@ -15,8 +15,7 @@
             {{ $isCurrent := eq $current . }}
             {{ $isAncestor := .IsAncestor $current }}
             {{ $id := substr (sha1 .Permalink) 0 8 }}
-            {{ $hasCollapse := and $isParent .Params.GeekdocCollapseSection }}
-            {{ $doCollapse := or $hasCollapse (default false .Site.Params.GeekdocCollapseAllSections) }}
+            {{ $doCollapse := and $isParent (or .Params.GeekdocCollapseSection (default false .Site.Params.GeekdocCollapseAllSections)) }}
 
             <li>
             {{ if $doCollapse }}


### PR DESCRIPTION
This allows setting `.Site.Params.GeekdocCollapseAllSections` which then
behaves as if you would have set `.Page.Params.geekdocCollapseSection`
in all sections.

It is a hard positive switch, so you can not override it per section
once enabled.