### PR TITLE
feat: Add CSS span to site title

### DIFF
--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -9,7 +9,7 @@
         <a class="gdoc-header__link" href="{{ .Root.Site.BaseURL }}">
             <span class="gdoc-brand flex align-center">
                 <img class="gdoc-brand__img" src="{{ (default "brand.svg" .Root.Site.Params.GeekdocLogo) | relURL }}" alt="">
-                <span class="gdoc-site-title">{{ .Root.Site.Title }}</span>
+                <span class="gdoc-brand__title">{{ .Root.Site.Title }}</span>
             </span>
         </a>
         <span id="gdoc-dark-mode">

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -9,7 +9,7 @@
         <a class="gdoc-header__link" href="{{ .Root.Site.BaseURL }}">
             <span class="gdoc-brand flex align-center">
                 <img class="gdoc-brand__img" src="{{ (default "brand.svg" .Root.Site.Params.GeekdocLogo) | relURL }}" alt="">
-                {{ .Root.Site.Title }}
+                <span class="gdoc-site-title">{{ .Root.Site.Title }}</span>
             </span>
         </a>
         <span id="gdoc-dark-mode">


### PR DESCRIPTION
On a geekdoc-based site I run (outfox.wiki), I had changed the header to use a larger logo, and hid the site title because it was redundant to said logo. However, I still wanted the text to be visible on mobile, which required some CSS to specifically target the site title text. So I did this.

Simple little QoL tweak.