### PR TITLE
fix: add div wrapper around markdown tables to allow overflows

### DIFF
--- a/layouts/partials/content.html
+++ b/layouts/partials/content.html
@@ -1,1 +1,4 @@
-{{ .Content | replaceRE `<nav id="TableOfContents">\s*<ul>\s*<li>\s*<ul>` `<nav id="TableOfContents"><ul>` | replaceRE `</ul>\s*</li>\s*</ul>\s*</nav>` `</ul></nav>` | safeHTML }}
+{{- $content := .Content -}}
+{{- $content = $content | replaceRE `<nav id="TableOfContents">\s*<ul>\s*<li>\s*<ul>` `<nav id="TableOfContents"><ul>` | replaceRE `</ul>\s*</li>\s*</ul>\s*</nav>` `</ul></nav>` | safeHTML -}}
+{{- $content = $content | replaceRE `(<table>(?:.|\n)+?</table>)` `<div class=table-wrap> ${1} </div>` | safeHTML -}}
+{{- $content -}}

--- a/src/sass/_markdown.scss
+++ b/src/sass/_markdown.scss
@@ -110,8 +110,11 @@
     }
   }
 
-  table:not(.lntable) {
+  .table-wrap {
     overflow: auto;
+  }
+
+  table:not(.lntable) {
     display: table;
     border-spacing: 0;
     border-collapse: collapse;


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/hugo-geekdoc/issues/176