### PR TITLE
Add Header Icon Links

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -35,3 +35,8 @@ params:
 
   geekdocImageLazyLoading: true
   geekdocDarkModeDim: true
+
+  geekdocHeaderIconLinks:
+    - href: https://github.com/thegeeklab/hugo-geekdoc
+      target: _blank
+      icon: gdoc_github

--- a/exampleSite/content/usage/configuration.md
+++ b/exampleSite/content/usage/configuration.md
@@ -97,6 +97,15 @@ enableGitInfo = true
 
   # (Optional, default true) Display a "Back to top" link in the site footer.
   geekdocBackToTop = true
+
+  # (Optional, default empty) Array of Header Icon Links to display on top right
+  [[params.geekdocHeaderIconLinks]]
+  # (Required) the link URL
+  href = "https://github.com/thegeeklab/hugo-geekdoc"
+  # (Optional, default empty) the link target, use "_blank" to open link in new window
+  target = "_blank"
+  # (Required) the SVG icon name, see Icon Sets page for options
+  icon = "gdoc_github"
 ```
 
 {{< /tab >}}
@@ -196,6 +205,15 @@ params:
 
   # (Optional, default true) Display a "Back to top" link in the site footer.
   geekdocBackToTop: true
+
+  # (Optional, default empty) Array of Header Icon Links to display on top right
+  geekdocHeaderIconLinks:
+      # (Required) the link URL
+    - href: https://github.com/thegeeklab/hugo-geekdoc
+      # (Optional, default empty) the link target, use "_blank" to open link in new window
+      target: _blank
+      # (Required) the SVG icon name, see Icon Sets page for options
+      icon: gdoc_github
 ```
 
 {{< /tab >}}

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -12,10 +12,17 @@
                 <span class="gdoc-brand__title">{{ .Root.Site.Title }}</span>
             </span>
         </a>
-        <span id="gdoc-dark-mode">
-            <svg class="icon gdoc_brightness_dark"><use xlink:href="#gdoc_brightness_dark"></use></svg>
-            <svg class="icon gdoc_brightness_light"><use xlink:href="#gdoc_brightness_light"></use></svg>
-            <svg class="icon gdoc_brightness_auto"><use xlink:href="#gdoc_brightness_auto"></use></svg>
-        </span>
+        <div>
+            {{- if .Root.Site.Params.GeekdocHeaderIconLinks }}
+            {{- range $_, $iconLink := .Root.Site.Params.GeekdocHeaderIconLinks }}
+            <a class="gdoc-header__link" href="{{ $iconLink.href }}" {{ if $iconLink.target }}target="{{ $iconLink.target }}"{{ end }}><svg class="icon {{ $iconLink.icon }}"><use xlink:href="#{{ $iconLink.icon }}"></use></svg></a>
+            {{- end }}
+            {{- end }}
+            <span id="gdoc-dark-mode">
+                <svg class="icon gdoc_brightness_dark"><use xlink:href="#gdoc_brightness_dark"></use></svg>
+                <svg class="icon gdoc_brightness_light"><use xlink:href="#gdoc_brightness_light"></use></svg>
+                <svg class="icon gdoc_brightness_auto"><use xlink:href="#gdoc_brightness_auto"></use></svg>
+            </span>
+        </div>
     </div>
 </header>

--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -170,7 +170,7 @@ img {
 
   &__link,
   &__link:visited {
-    color: inherit;
+    color: var(--header-font-color);
   }
 
   &__link:hover {


### PR DESCRIPTION
Adds optional `geekdocHeaderIconLinks` array to site configuration.  Spec:

```yaml
  # (Optional, default empty) Array of Header Icon Links to display on top right
  geekdocHeaderIconLinks:
      # (Required) the link URL
    - href: https://github.com/thegeeklab/hugo-geekdoc
      # (Optional, default empty) the link target, use "_blank" to open link in new window
      target: _blank
      # (Required) the SVG icon name, see Icon Sets page for options
      icon: gdoc_github
```

Example:

![image](https://user-images.githubusercontent.com/2414837/128741813-51ef7d20-5a5b-48fe-9c0c-da4de10f7713.png)