### PR TITLE
Use path.Join on "Edit this page" hyperlink

### DIFF
--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -39,7 +39,7 @@
     <div>
         <span class="editpage">
             <svg class="icon gdoc_code"><use xlink:href="#gdoc_code"></use></svg>
-            <a href="{{ $geekdocRepo }}/{{ $geekdocEditPath }}/{{ $.Scratch.Get "geekdocFilePath" }}">
+            <a href="{{ path.Join $geekdocRepo $geekdocEditPath ($.Scratch.Get "geekdocFilePath") }}">
                 Edit this page
             </a>
         </span>

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -39,7 +39,7 @@
     <div>
         <span class="editpage">
             <svg class="icon gdoc_code"><use xlink:href="#gdoc_code"></use></svg>
-            <a href="{{ path.Join $geekdocRepo $geekdocEditPath ($.Scratch.Get "geekdocFilePath") }}">
+            <a href="{{ $geekdocRepo }}/{{ path.Join $geekdocEditPath ($.Scratch.Get "geekdocFilePath") }}">
                 Edit this page
             </a>
         </span>


### PR DESCRIPTION
Using path.Join cleans up the line a bit and also avoids a current issue Windows users have using this theme, per https://github.com/gohugoio/hugo/issues/8885.
In the event no change is done to Hugo (and I assume the change won't be done since it's a very low-level functionality change), this at least helps this implementation and solves https://github.com/thegeeklab/hugo-geekdoc/issues/185