### PR TITLE
chore: remove rss link from header

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -23,6 +23,18 @@ markup:
 taxonomies:
   tag: tags
 
+outputs:
+  home:
+    - HTML
+  page:
+    - HTML
+  section:
+    - HTML
+  taxonomy:
+    - HTML
+  term:
+    - HTML
+
 params:
   # geekdocMenuBundle: true
   geekdocToC: 3

--- a/layouts/partials/head/others.html
+++ b/layouts/partials/head/others.html
@@ -15,10 +15,6 @@
 <link rel="preload" href="{{ index .Site.Data.assets "custom.css" | relURL }}" as="style">
 <link rel="stylesheet" href="{{ index .Site.Data.assets "custom.css" | relURL }}" media="all">
 
-{{ with .OutputFormats.Get "rss" -}}
-    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
-{{ end -}}
-
 {{ if (default false $.Site.Params.GeekdocOverwriteHTMLBase) }}
 <base href="{{ .Site.BaseURL }}">
 {{ end }}


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/hugo-geekdoc/issues/201

Feeds are not implemented for this theme.