### PR TITLE
fix: fix broken `Edit Page` links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,8 @@ exampleSite/content/de
 /exampleSite/resources/
 /exampleSite/data/sprites/
 
+# hugo
+.hugo_build.lock
+
 # testing
 .lighthouseci/

--- a/exampleSite/.gitignore
+++ b/exampleSite/.gitignore
@@ -1,1 +1,0 @@
-.hugo_build.lock

--- a/exampleSite/.gitignore
+++ b/exampleSite/.gitignore
@@ -1,0 +1,1 @@
+.hugo_build.lock

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -1,7 +1,7 @@
 {{ $geekdocRepo := default (default false .Site.Params.GeekdocRepo) .Page.Params.GeekdocRepo }}
 {{ $geekdocEditPath := default (default false .Site.Params.GeekdocEditPath) .Page.Params.GeekdocEditPath }}
 {{ if .File }}
-  {{ $.Scratch.Set "geekdocFilePath" (default ( path.Join .File.Lang .File.Path ) .Page.Params.GeekdocFilePath) }}
+  {{ $.Scratch.Set "geekdocFilePath" (default (path.Join .File.Lang .File.Path) .Page.Params.GeekdocFilePath) }}
 {{ else }}
   {{ $.Scratch.Set "geekdocFilePath" false }}
 {{ end }}

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -1,7 +1,7 @@
 {{ $geekdocRepo := default (default false .Site.Params.GeekdocRepo) .Page.Params.GeekdocRepo }}
 {{ $geekdocEditPath := default (default false .Site.Params.GeekdocEditPath) .Page.Params.GeekdocEditPath }}
 {{ if .File }}
-  {{ $.Scratch.Set "geekdocFilePath" (default .File.Path .Page.Params.GeekdocFilePath) }}
+  {{ $.Scratch.Set "geekdocFilePath" (default ( path.Join .File.Lang .File.Path ) .Page.Params.GeekdocFilePath) }}
 {{ else }}
   {{ $.Scratch.Set "geekdocFilePath" false }}
 {{ end }}


### PR DESCRIPTION
**Documentation at https://geekdocs.de:**

The links [Edit page] located top right are currently broken on all pages. This PR fixes this issue.

