### PR TITLE
fix: fix edit page link and auto-detect contentDir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,8 @@ exampleSite/content/de
 /exampleSite/resources/
 /exampleSite/data/sprites/
 
+# hugo
+.hugo_build.lock
+
 # testing
 .lighthouseci/

--- a/exampleSite/config/_default/params.yaml
+++ b/exampleSite/config/_default/params.yaml
@@ -8,7 +8,7 @@ geekdocToC: 3
 geekdocTagsToMenu: true
 
 geekdocRepo: https://github.com/thegeeklab/hugo-geekdoc
-geekdocEditPath: edit/main/exampleSite/content
+geekdocEditPath: edit/main/exampleSite
 
 geekdocSearch: true
 geekdocSearchShowParent: true

--- a/exampleSite/content/en/usage/configuration.md
+++ b/exampleSite/content/en/usage/configuration.md
@@ -264,7 +264,7 @@ geekdocRepo = "https://github.com/thegeeklab/hugo-geekdoc"
 
 # Enable 'Edit page' links. Requires 'GeekdocRepo' param and the path must point to
 # the parent directory of the 'content' folder.
-geekdocEditPath = "edit/main/exampleSite/content"
+geekdocEditPath = "edit/main/exampleSite"
 
 # Used for 'Edit page' link, set to '.File.Path' by default.
 # Can be overwritten by a path relative to 'geekdocEditPath'

--- a/exampleSite/content/en/usage/configuration.md
+++ b/exampleSite/content/en/usage/configuration.md
@@ -50,7 +50,7 @@ enableRobotsTXT = true
   geekdocMenuBundle = true
 
   # (Optional, default false) Collapse all menu entries, can not be overwritten
-  # per page if enabled. Can be enabled per page via `geekdocCollapseSection`.
+  # per page if enabled. Can be enabled per page via 'geekdocCollapseSection'.
   geekdocCollapseAllSections = true
 
   # (Optional, default true) Show page navigation links at the bottom of each
@@ -66,9 +66,9 @@ enableRobotsTXT = true
   geekdocRepo = "https://github.com/thegeeklab/hugo"
 
   # (Optional, default none) Enable 'Edit page' links. Requires 'GeekdocRepo' param
-  # and path must point to 'content' directory of repo.
+  # and the path must point to the parent directory of the 'content' folder.
   # You can also specify this parameter per page in front matter.
-  geekdocEditPath = "edit/main/exampleSite/content"
+  geekdocEditPath = "edit/main/exampleSite"
 
   # (Optional, default true) Enables search function with flexsearch.
   # Index is built on the fly and might slow down your website.
@@ -163,7 +163,7 @@ params:
   geekdocMenuBundle: true
 
   # (Optional, default false) Collapse all menu entries, can not be overwritten
-  # per page if enabled. Can be enabled per page via `geekdocCollapseSection`.
+  # per page if enabled. Can be enabled per page via 'geekdocCollapseSection'.
   geekdocCollapseAllSections: true
 
   # (Optional, default true) Show page navigation links at the bottom of each
@@ -178,10 +178,10 @@ params:
   # You can also specify this parameter per page in front matter.
   geekdocRepo: "https://github.com/thegeeklab/hugo-geekdoc"
 
-  # (Optional, default none) Enable "Edit page" links. Requires 'GeekdocRepo' param
-  # and path must point to 'content' directory of repo.
+  # (Optional, default none) Enable 'Edit page' links. Requires 'GeekdocRepo' param
+  # and the path must point to the parent directory of the 'content' folder.
   # You can also specify this parameter per page in front matter.
-  geekdocEditPath: edit/main/exampleSite/content
+  geekdocEditPath: edit/main/exampleSite
 
   # (Optional, default true) Enables search function with flexsearch.
   # Index is built on the fly and might slow down your website.
@@ -262,8 +262,8 @@ geekdocBreadcrumb = false
 # Set source repository location.
 geekdocRepo = "https://github.com/thegeeklab/hugo-geekdoc"
 
-# Enable "Edit page" links. Requires 'GeekdocRepo' param and path must point
-# to 'content' directory of repo.
+# Enable 'Edit page' links. Requires 'GeekdocRepo' param and the path must point to
+# the parent directory of the 'content' folder.
 geekdocEditPath = "edit/main/exampleSite/content"
 
 # Used for 'Edit page' link, set to '.File.Path' by default.
@@ -322,9 +322,9 @@ geekdocBreadcrumb: false
 # Set source repository location.
 geekdocRepo: "https://github.com/thegeeklab/hugo-geekdoc"
 
-# Enable "Edit page" links. Requires 'GeekdocRepo' param and path must point
-# to 'content' directory of repo.
-geekdocEditPath: "edit/main/exampleSite/content"
+# Enable 'Edit page' links. Requires 'GeekdocRepo' param and the path must point to
+# the parent directory of the 'content' folder.
+geekdocEditPath: "edit/main/exampleSite"
 
 # Used for 'Edit page' link, set to '.File.Path' by default.
 # Can be overwritten by a path relative to 'geekdocEditPath'

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -1,7 +1,7 @@
 {{ $geekdocRepo := default (default false .Site.Params.GeekdocRepo) .Page.Params.GeekdocRepo }}
 {{ $geekdocEditPath := default (default false .Site.Params.GeekdocEditPath) .Page.Params.GeekdocEditPath }}
 {{ if .File }}
-  {{ $.Scratch.Set "geekdocFilePath" (default .File.Path .Page.Params.GeekdocFilePath) }}
+  {{ $.Scratch.Set "geekdocFilePath" (default (path.Join .Site.Params.contentDir .File.Path) .Page.Params.GeekdocFilePath) }}
 {{ else }}
   {{ $.Scratch.Set "geekdocFilePath" false }}
 {{ end }}


### PR DESCRIPTION
BREAKING CHANGE: With support of the multilingual mode, we broke the `edit page` links, as the content directory was statically hard-coded into the `GeekdocEditPath` parameter. To get the correct content directory, regardless of the language or a disabled multilingual mode, we now use Hugo's built-in `.Site.Params.contentDir` parameter. Therefor, you have to remove the hard-coded `/content` part from the `geekdocEditPath` parameter in the configuration of your project.