### PR TITLE
Render mermaid codeblocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /exampleSite/public/
 /exampleSite/config/development/
 CHANGELOG.md
+VERSION
 
 # translation envs
 exampleSite/content/de

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ npm install
 
 # run the build script to build required assets
 npm run build
+
+# build release tarball
+echo "${VERSION:-development}" > VERSION
+tar czf "dist/hugo-geekdoc-${VERSION:-development}.tar.gz" \
+  archetypes assets data i18n images layouts static \
+  theme.toml LICENSE README.md VERSION
 ```
 
 See the [Getting Started Guide](https://geekdocs.de/usage/getting-started/) for details about the different setup options.

--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,12 @@
+<!-- prettier-ignore-start -->
+{{ if not (.Page.Scratch.Get "mermaid") }}
+  <!-- Include mermaid only first time -->
+  <script defer src="{{ index (index .Site.Data.assets "mermaid.js") "src" | relURL }}"></script>
+  {{ .Page.Scratch.Set "mermaid" true }}
+{{ end }}
+<!-- prettier-ignore-end -->
+
+{{ .Page.Scratch.Set "mermaid" true }}
+<pre class="gdoc-mermaid mermaid">
+  {{- .Inner -}}
+</pre>

--- a/layouts/partials/foot.html
+++ b/layouts/partials/foot.html
@@ -4,8 +4,3 @@
   {{- $searchConfig := resources.Get "search/config.json" | resources.ExecuteAsTemplate $searchConfigFile . | resources.Minify -}}
   {{- $searchConfig.Publish -}}
 {{ end }}
-
-<!-- Include mermaid if not already included by a shortcode but a mermaid code fence is present -->
-{{ if and (findRE "[\n^]```mermaid[\n ]" .RawContent) (not (.Scratch.Get "mermaid")) }}
-  <script defer src="{{ index (index .Site.Data.assets "mermaid.js") "src" | relURL }}"></script>
-{{ end }}

--- a/layouts/partials/foot.html
+++ b/layouts/partials/foot.html
@@ -4,3 +4,8 @@
   {{- $searchConfig := resources.Get "search/config.json" | resources.ExecuteAsTemplate $searchConfigFile . | resources.Minify -}}
   {{- $searchConfig.Publish -}}
 {{ end }}
+
+<!-- Include mermaid if not already included by a shortcode but a mermaid code fence is present -->
+{{ if and (findRE "[\n^]```mermaid[\n ]" .RawContent) (not (.Scratch.Get "mermaid")) }}
+  <script defer src="{{ index (index .Site.Data.assets "mermaid.js") "src" | relURL }}"></script>
+{{ end }}

--- a/src/js/mermaid.js
+++ b/src/js/mermaid.js
@@ -18,12 +18,19 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
   import("mermaid")
     .then(({ default: md }) => {
+      // Configure mermaid with matching color scheme
       md.initialize({
         flowchart: { useMaxWidth: true },
         theme: theme,
         themeVariables: {
           darkMode: darkMode
         }
+      })
+
+      // Render mermaid from shortcodes and code fences
+      md.init(undefined, ".mermaid,.language-mermaid", (id) => {
+        // Fix height of mermaid SVG elements (see https://github.com/mermaid-js/mermaid/issues/2481)
+        document.getElementById(id).setAttribute("height", "100%")
       })
     })
     .catch((error) => console.error(error))

--- a/src/js/mermaid.js
+++ b/src/js/mermaid.js
@@ -18,19 +18,18 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
   import("mermaid")
     .then(({ default: md }) => {
-      // Configure mermaid with matching color scheme
       md.initialize({
         flowchart: { useMaxWidth: true },
         theme: theme,
         themeVariables: {
           darkMode: darkMode
+        },
+        mermaid: {
+          // Fix height of mermaid SVG elements (see https://github.com/mermaid-js/mermaid/issues/2481)
+          callback: (id) => {
+            document.getElementById(id).setAttribute("height", "100%")
+          }
         }
-      })
-
-      // Render mermaid from shortcodes and code fences
-      md.init(undefined, ".mermaid,.language-mermaid", (id) => {
-        // Fix height of mermaid SVG elements (see https://github.com/mermaid-js/mermaid/issues/2481)
-        document.getElementById(id).setAttribute("height", "100%")
       })
     })
     .catch((error) => console.error(error))


### PR DESCRIPTION
This PR adds support for rendering mermaid in codeblocks / code fences.

Examples I was able to find for this feature, like https://anis.se/posts/add-mermaidjs-support-to-hugo/, had a few issues.

1. Imported mermaid more than once
2. Imported mermaid from different sources/versions
3. Did not support dark mode

Sorry for not creating an issue first, like it recommends in CONTRIBUTING.md. However, I figured that this probably wasn't something that would be desired for the mainline release, since it changes existing behavior. If I'm wrong, maybe it can be put behind a config flag.

I also inserted a personal fix for https://github.com/mermaid-js/mermaid/issues/2481, which may need to be omitted if this PR is to be considered for merge.

Maintainers: feel free to close this PR if you're not interested in the feature. I just hope that it helps some poor fool like past me who searches for "geekdoc mermaid codeblock / code fence support!"

EDIT: My branch is currently based off of v0.33.2, because Mermaid v9.1.4 is broken in such a way that having multiple sequence diagrams in one page cumulatively joins them! So sequence 1, sequence 1+2, sequence 1+3.

EDIT 2: Mermaid v9.1.5 and v9.1.6 seem to fix the error, so I will rebase this to merge into main, which already has updated to v9.1.5.

EDIT 3: The mermaid 9.1.4 bug being referenced was https://github.com/mermaid-js/mermaid/issues/3305 and was fixed here: https://github.com/mermaid-js/mermaid/pull/3310