### PR TITLE
feat: add origin size to image shortcode

### DIFF
--- a/exampleSite/content/en/shortcodes/images/_index.md
+++ b/exampleSite/content/en/shortcodes/images/_index.md
@@ -43,12 +43,12 @@ If you need more flexibility for your embedded images, you could use the `img` s
 
 ## Attributes
 
-| Name | Description                                             | default           |
-| ---- | ------------------------------------------------------- | ----------------- |
-| name | name of the image resource defined in your front matter | empty             |
-| alt  | description for displayed image                         | resource `.Title` |
-| size | Thumbnail size (profile\|tiny\|small\|medium\|large)    | empty             |
-| lazy | enable or disable image lazy loading                    | true              |
+| Name | Description                                                  | default           |
+| ---- | ------------------------------------------------------------ | ----------------- |
+| name | name of the image resource defined in your front matter      | empty             |
+| alt  | description for displayed image                              | resource `.Title` |
+| size | Thumbnail size (origin\|profile\|tiny\|small\|medium\|large) | empty             |
+| lazy | enable or disable image lazy loading                         | true              |
 
 ## Usage
 
@@ -75,7 +75,7 @@ resources:
 
 <!-- spellchecker-disable -->
 
-{{< img name="forest-1" lazy=false >}}
+{{< img name="forest-1" size="origin" lazy=false >}}
 
 <!-- spellchecker-enable -->
 

--- a/exampleSite/content/en/shortcodes/images/_index.md
+++ b/exampleSite/content/en/shortcodes/images/_index.md
@@ -75,7 +75,7 @@ resources:
 
 <!-- spellchecker-disable -->
 
-{{< img name="forest-1" size="origin" lazy=false >}}
+{{< img name="forest-1" lazy=false >}}
 
 <!-- spellchecker-enable -->
 

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -6,18 +6,19 @@
 {{- with $source }}
   {{- $caption := default .Title $customAlt }}
 
+  {{- $origin := .Permalink }}
   {{- $profile := (.Fill "180x180 Center").Permalink }}
   {{- $tiny := (.Resize "320x").Permalink }}
   {{- $small := (.Resize "600x").Permalink }}
   {{- $medium := (.Resize "1200x").Permalink }}
   {{- $large := (.Resize "1800x").Permalink }}
 
-  {{- $size := dict "profile" $profile "tiny" $tiny "small" $small "medium" $medium "large" $large }}
+  {{- $size := dict "origin" $origin "profile" $profile "tiny" $tiny "small" $small "medium" $medium "large" $large }}
 
 
   <div class="flex justify-center">
     <figure
-      class="gdoc-post__figure
+      class="gdoc-markdown__figure
       {{- if eq $customSize "profile" }}{{ print " gdoc-post__figure--round" }}{{ end }}"
     >
       <a class="gdoc-markdown__link--raw" href="{{ .Permalink }}">
@@ -31,7 +32,11 @@
           />
           <img
             {{- if $lazyLoad }}{{ print " loading=\"lazy\"" | safeHTMLAttr }}{{- end }}
-            src="{{ $size.large }}"
+            {{- if eq $customSize "origin" }}
+              src="{{ $size.origin }}"
+            {{- else }}
+              src="{{ $size.large }}"
+            {{- end }}
             alt="{{ $caption }}"
           />
         </picture>


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/hugo-geekdoc/issues/489

The size `origin` will embed the image as it is without rescaling.