### PR TITLE
use .Page.Site instead of site to access data assets

### DIFF
--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,7 +1,7 @@
 <!-- prettier-ignore-start -->
 {{ if not (.Page.Scratch.Get "mermaid") }}
   <!-- Include mermaid only first time -->
-  <script defer src="{{ index (index site.Data.assets "mermaid.js") "src" | relURL }}"></script>
+  <script defer src="{{ index (index .Page.Site.Data.assets "mermaid.js") "src" | relURL }}"></script>
   {{ .Page.Scratch.Set "mermaid" true }}
 {{ end }}
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
As we use `.Page.Site` in other places of the theme, already stick to this method instead of the global `site` function.