### PR TITLE
feat: add support for custom heading CSS class

### DIFF
--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -4,7 +4,10 @@
 <!-- prettier-ignore-start -->
 {{- if $showAnchor -}}
 <div class="gdoc-page__anchorwrap">
-    <h{{ .Level }} id="{{ .Anchor | safeURL }}">
+    <h{{ .Level }} id="{{ .Anchor | safeURL }}" {{- with .Attributes.class }}
+        class="{{ . }}"
+    {{- end }}
+    >
         {{ .Text | safeHTML }}
         <a data-clipboard-text="{{ .Page.Permalink }}#{{ .Anchor | safeURL }}" class="gdoc-page__anchor clip flex align-center" title="{{ i18n "title_anchor_prefix" }} {{ .Text | safeHTML }}" aria-label="{{ i18n "title_anchor_prefix" }} {{ .Text | safeHTML }}" href="#{{ .Anchor | safeURL }}">
             <svg class="gdoc-icon gdoc_link"><use xlink:href="#gdoc_link"></use></svg>
@@ -13,7 +16,10 @@
 </div>
 {{- else -}}
 <div class="gdoc-page__anchorwrap">
-    <h{{ .Level }} id="{{ .Anchor | safeURL }}">
+    <h{{ .Level }} id="{{ .Anchor | safeURL }}" {{- with .Attributes.class }}
+        class="{{ . }}"
+    {{- end }}
+    >
         {{ .Text | safeHTML }}
     </h{{ .Level }}>
 </div>


### PR DESCRIPTION
This is a Goldmark supported [feature](https://github.com/yuin/goldmark/#attributes) that isn’t reflected in GeekDoc theme.

This PR **only** adds support for custom heading CSS classes (`.className` and `class="class1 class2"`). Custom ids are not supported, nor any other custom attribute (`#id` and `attrName=attrValue`).