### PR TITLE
fix: utilize hugo.WorkingDir for a reliable edit page link

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,7 +26,7 @@ steps:
       NPM_CONFIG_LOGLEVEL: error
 
   - name: testbuild
-    image: thegeeklab/hugo:0.114.0
+    image: thegeeklab/hugo:0.115.2
     commands:
       - mkdir -p exampleSite/themes/ && ln -s $(pwd)/ exampleSite/themes/hugo-geekdoc
       - hugo --panicOnWarning -s exampleSite/ -b http://localhost:8000/
@@ -173,7 +173,7 @@ steps:
         - refs/pull/**
 
   - name: build
-    image: thegeeklab/hugo:0.114.0
+    image: thegeeklab/hugo:0.115.2
     commands:
       - hugo --panicOnWarning -s exampleSite/
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Geekdoc
 
 [![Build Status](https://img.shields.io/drone/build/thegeeklab/hugo-geekdoc?logo=drone&server=https%3A%2F%2Fdrone.thegeeklab.de)](https://drone.thegeeklab.de/thegeeklab/hugo-geekdoc)
-[![Hugo Version](https://img.shields.io/badge/hugo-0.93-blue.svg)](https://gohugo.io)
+[![Hugo Version](https://img.shields.io/badge/hugo-0.112-blue.svg)](https://gohugo.io)
 [![GitHub release](https://img.shields.io/github/v/release/thegeeklab/hugo-geekdoc)](https://github.com/thegeeklab/hugo-geekdoc/releases/latest)
 [![GitHub contributors](https://img.shields.io/github/contributors/thegeeklab/hugo-geekdoc)](https://github.com/thegeeklab/hugo-geekdoc/graphs/contributors)
 [![License: MIT](https://img.shields.io/github/license/thegeeklab/hugo-geekdoc)](https://github.com/thegeeklab/hugo-geekdoc/blob/main/LICENSE)

--- a/exampleSite/content/en/_index.md
+++ b/exampleSite/content/en/_index.md
@@ -9,7 +9,7 @@ geekdocAnchor: false
 <!-- markdownlint-disable MD033 -->
 
 <span class="badge-placeholder">[![Build Status](https://img.shields.io/drone/build/thegeeklab/hugo-geekdoc?logo=drone&server=https%3A%2F%2Fdrone.thegeeklab.de)](https://drone.thegeeklab.de/thegeeklab/hugo-geekdoc)</span>
-<span class="badge-placeholder">[![Hugo Version](https://img.shields.io/badge/hugo-0.93-blue.svg)](https://gohugo.io)</span>
+<span class="badge-placeholder">[![Hugo Version](https://img.shields.io/badge/hugo-0.112-blue.svg)](https://gohugo.io)</span>
 <span class="badge-placeholder">[![GitHub release](https://img.shields.io/github/v/release/thegeeklab/hugo-geekdoc)](https://github.com/thegeeklab/hugo-geekdoc/releases/latest)</span>
 <span class="badge-placeholder">[![GitHub contributors](https://img.shields.io/github/contributors/thegeeklab/hugo-geekdoc)](https://github.com/thegeeklab/hugo-geekdoc/graphs/contributors)</span>
 <span class="badge-placeholder">[![License: MIT](https://img.shields.io/github/license/thegeeklab/hugo-geekdoc)](https://github.com/thegeeklab/hugo-geekdoc/blob/main/LICENSE)</span>

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -1,7 +1,7 @@
 {{ $geekdocRepo := default (default false .Site.Params.geekdocRepo) .Page.Params.geekdocRepo }}
 {{ $geekdocEditPath := default (default false .Site.Params.geekdocEditPath) .Page.Params.geekdocEditPath }}
 {{ if .File }}
-  {{ $.Scratch.Set "geekdocFilePath" (default (path.Join (default "content" .Site.Params.contentDir) .File.Path) .Page.Params.geekdocFilePath) }}
+  {{ $.Scratch.Set "geekdocFilePath" (default (strings.TrimPrefix hugo.WorkingDir .File.Filename) .Page.Params.geekdocFilePath) }}
 {{ else }}
   {{ $.Scratch.Set "geekdocFilePath" false }}
 {{ end }}

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "Hugo theme made for documentation"
 homepage = "https://geekdocs.de/"
 demosite = "https://geekdocs.de/"
 tags = ["docs", "documentation", "responsive", "simple"]
-min_version = "0.93.0"
+min_version = "0.112.0"
 
 [author]
     name = "Robert Kaussow"


### PR DESCRIPTION
BREAKING CHANGE: The `Edit page` uses the `hugo.WorkingDir` function of Hugo, which was introduced in v0.112.0. Due to this change, the minimum Hugo version for the theme has been raised accordingly.

Fixes: https://github.com/thegeeklab/hugo-geekdoc/issues/663