### PR TITLE
fix: remove htmlUnescape from expand shortcode

### DIFF
--- a/layouts/shortcodes/expand.html
+++ b/layouts/shortcodes/expand.html
@@ -6,6 +6,6 @@
   </label>
   <input id="{{ $id }}-{{ .Ordinal }}" type="checkbox" class="gdoc-expand__control hidden" />
   <div class="gdoc-markdown--nested gdoc-expand__content">
-    {{ .Inner | $.Page.RenderString | htmlUnescape | safeHTML }}
+    {{ .Inner | $.Page.RenderString }}
   </div>
 </div>


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/hugo-geekdoc/issues/666
Partially reverts: https://github.com/thegeeklab/hugo-geekdoc/pull/415

I was not able to reproduce the original formatting issue. If it occurs again, we need to find a better solution and document it.