### PR TITLE
Fixed CSS issue with Safari

### DIFF
--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -655,7 +655,7 @@ svg.gdoc-icon {
   }
 
   &:focus-within &__list.has-hits,
-  &__list.has-hits:active {
+  &__list.has-hits:hover {
     visibility: visible;
   }
 }


### PR DESCRIPTION
On Safari the :activation-off triggers before the a-href hits. The result is that the searchbox will disapear before the new page is called. Fixed by replacing :active with :hover