### PR TITLE
docs: use a propertylist to document shortcode attributes

### DIFF
--- a/exampleSite/content/en/shortcodes/buttons.md
+++ b/exampleSite/content/en/shortcodes/buttons.md
@@ -4,11 +4,20 @@ title: Buttons
 
 Buttons are styled links that can lead to local page or external link.
 
-<!-- prettier-ignore-start -->
+## Usage
+
+<!-- prettier-ignore -->
 ```tpl
 {{</* button relref="/" [class="...", size="large|regular"] */>}}Get Home{{</* /button */>}}
 {{</* button href="https://github.com/thegeeklab/hugo-geekdoc" */>}}Contribute{{</* /button */>}}
 ```
+
+### Attributes
+
+<!-- prettier-ignore-start -->
+<!-- spellchecker-disable -->
+{{< propertylist name=shortcode-buttons sort=name order=asc >}}
+<!-- spellchecker-enable -->
 <!-- prettier-ignore-end -->
 
 ## Example

--- a/exampleSite/content/en/shortcodes/columns.md
+++ b/exampleSite/content/en/shortcodes/columns.md
@@ -4,15 +4,9 @@ title: Columns
 
 The Columns shortcode can be used to organize content side-by-side (horizontally) for better readability.
 
-## Attributes
-
-| Name            | Description                                      | default |
-| --------------- | ------------------------------------------------ | ------- |
-| size (optional) | size of the first column (small\|regular\|large) | regular |
-
 ## Usage
 
-```html
+```tpl
 {{</* columns */>}} <!-- begin columns block -->
 ## Left Content
 Dolor sit, sumo unique argument um no ...
@@ -29,11 +23,19 @@ Dolor sit, sumo unique argument um no ...
 {{</* /columns */>}}
 ```
 
+### Attributes
+
+<!-- prettier-ignore-start -->
+<!-- spellchecker-disable -->
+{{< propertylist name=shortcode-columns sort=name order=asc >}}
+<!-- spellchecker-enable -->
+<!-- prettier-ignore-end -->
+
 ## Example
 
 {{< columns >}}
 
-## Left
+### Left
 
 Dolor sit, sumo unique argument um no. Gracie nominal id xiv. Romanesque acclimates
 investiture. Ornateness bland it ex enc, est yeti am bongo detract re. Pro ad prompts
@@ -42,14 +44,14 @@ copious quo ad. Stet probates in duo.
 
 <--->
 
-## Mid Content
+### Mid Content
 
 Dolor sit, sumo unique argument um no. Gracie nominal id xiv. Romanesque acclimates
 investiture. Ornateness bland it ex enc, est yeti am bongo detract re.
 
 <--->
 
-## Right Content
+### Right Content
 
 Dolor sit, sumo unique argument um no. Gracie nominal id xiv. Romanesque acclimates
 investiture. Ornateness bland it ex enc, est yeti am bongo detract re. Pro ad prompts

--- a/exampleSite/content/en/shortcodes/columns.md
+++ b/exampleSite/content/en/shortcodes/columns.md
@@ -6,7 +6,7 @@ The Columns shortcode can be used to organize content side-by-side (horizontally
 
 ## Usage
 
-```tpl
+```html
 {{</* columns */>}} <!-- begin columns block -->
 ## Left Content
 Dolor sit, sumo unique argument um no ...

--- a/exampleSite/content/en/shortcodes/expand.md
+++ b/exampleSite/content/en/shortcodes/expand.md
@@ -4,40 +4,38 @@ title: Expand
 
 Expand shortcode can help to decrease clutter on screen by hiding part of text. Expand content by clicking on it.
 
-## Example
+## Usage
 
-### Default
-
-<!-- prettier-ignore-start -->
 ```tpl
 {{</* expand */>}}
-## Markdown content
+### Markdown content
 Dolor sit, sumo unique ...
 {{</* /expand */>}}
 ```
-<!-- prettier-ignore-end -->
+
+It is also possible to use a custom label and symbol.
+
+<!-- prettier-ignore-start -->
+
+```tpl
+{{</* expand "Custom Label" "..." */>}}
+### More markdown
+Dolor sit, sumo unique ...
+{{</* /expand */>}}
+```
+
+## Example
 
 {{< expand >}}
 
-## Markdown content
+### Markdown content
 
 Dolor sit, sumo unique argument um no. Gracie nominal id xiv. Romanesque acclimates investiture. Ornateness bland it ex enc, est yeti am bongo detract re.
 {{< /expand >}}
 
-### With Custom Label
-
-<!-- prettier-ignore-start -->
-```tpl
-{{</* expand "Custom Label" "..." */>}}
-## Markdown content
-Dolor sit, sumo unique ...
-{{</* /expand */>}}
-```
-<!-- prettier-ignore-end -->
-
 {{< expand "Custom Label" "..." >}}
 
-## More markdown
+### More markdown
 
 Dolor sit, sumo unique argument um no. Gracie nominal id xiv. Romanesque acclimates
 investiture. Ornateness bland it ex enc, est yeti am bongo detract re. Pro ad prompts

--- a/exampleSite/content/en/shortcodes/hints.md
+++ b/exampleSite/content/en/shortcodes/hints.md
@@ -4,14 +4,6 @@ title: Hints
 
 Hint shortcode can be used as hint/alerts/notification block.
 
-## Attributes
-
-| Name             | Description                                                                      | default   |
-| ---------------- | -------------------------------------------------------------------------------- | --------- |
-| type             | hint type                                                                        | note      |
-| icon (optional)  | custom icon to use,need to be an icon from an [SVG sprite](/features/icon-sets/) | undefined |
-| title (optional) | hint title                                                                       | undefined |
-
 ## Usage
 
 <!-- prettier-ignore-start -->
@@ -22,6 +14,14 @@ Dolor sit, sumo unique argument um no. Gracie nominal id xiv. Romanesque acclima
  Ornateness bland it ex enc, est yeti am bongo detract re.
 {{</* /hint */>}}
 ```
+<!-- prettier-ignore-end -->
+
+### Attributes
+
+<!-- prettier-ignore-start -->
+<!-- spellchecker-disable -->
+{{< propertylist name=shortcode-hints sort=name order=asc >}}
+<!-- spellchecker-enable -->
 <!-- prettier-ignore-end -->
 
 ## Example

--- a/exampleSite/content/en/shortcodes/icons.md
+++ b/exampleSite/content/en/shortcodes/icons.md
@@ -4,15 +4,17 @@ title: Icons
 
 Simple shortcode to include icons from SVG sprites outside of menus.
 
+## Usage
+
 <!-- prettier-ignore-start -->
 ```tpl
 {{</* icon "thumbs-up" */>}}
 ```
 <!-- prettier-ignore-end -->
 
-## Usage
+## Example
 
-| Result                     | Usage                            |
+| Output                     | Code                             |
 | -------------------------- | -------------------------------- |
 | {{< icon "thumbs-up" >}}   | `{{</* icon "thumbs-up" */>}}`   |
 | {{< icon "thumbs-down" >}} | `{{</* icon "thumbs-down" */>}}` |

--- a/exampleSite/content/en/shortcodes/images/_index.md
+++ b/exampleSite/content/en/shortcodes/images/_index.md
@@ -46,15 +46,6 @@ resources:
 If you need more flexibility for your embedded images, you could use the `img` shortcode. It is using Hugo's
 [page resources](https://gohugo.io/content-management/page-resources/) and supports lazy loading of your images.
 
-## Attributes
-
-| Name | Description                                                  | default           |
-| ---- | ------------------------------------------------------------ | ----------------- |
-| name | name of the image resource defined in your front matter      | empty             |
-| alt  | description for displayed image                              | resource `.Title` |
-| size | Thumbnail size (origin\|profile\|tiny\|small\|medium\|large) | empty             |
-| lazy | enable or disable image lazy loading                         | true              |
-
 ## Usage
 
 Define your resources in the page front matter, custom parameter `params.credits` is optional.
@@ -73,6 +64,14 @@ resources:
 
 {{</* img name="forest-1" size="large" lazy=false */>}}
 ```
+
+### Attributes
+
+<!-- prettier-ignore-start -->
+<!-- spellchecker-disable -->
+{{< propertylist name=shortcode-images sort=name order=asc >}}
+<!-- spellchecker-enable -->
+<!-- prettier-ignore-end -->
 
 <!-- spellchecker-enable -->
 

--- a/exampleSite/content/en/shortcodes/includes.md
+++ b/exampleSite/content/en/shortcodes/includes.md
@@ -2,9 +2,9 @@
 title: Includes
 ---
 
-{{< toc >}}
-
 Include shortcode can include files of different types. By specifying a language, the included file will have syntax highlighting.
+
+## Usage
 
 <!-- prettier-ignore-start -->
 ```tpl
@@ -12,18 +12,17 @@ Include shortcode can include files of different types. By specifying a language
 ```
 <!-- prettier-ignore-end -->
 
-Attributes:
+### Attributes
 
-| Name     | Description                                                                                                                         | Default                          |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
-| file     | path to the included file relative to the Hugo root                                                                                 | undefined                        |
-| language | language for [syntax highlighting](https://gohugo.io/content-management/syntax-highlighting/#list-of-chroma-highlighting-languages) | undefined                        |
-| type     | special include type (`html,page`)                                                                                                  | undefined (rendered as markdown) |
-| options  | highlighting [options](https://gohugo.io/content-management/syntax-highlighting/#highlight-shortcode)                               | `linenos=table`                  |
+<!-- prettier-ignore-start -->
+<!-- spellchecker-disable -->
+{{< propertylist name=shortcode-includes sort=name order=asc >}}
+<!-- spellchecker-enable -->
+<!-- prettier-ignore-end -->
 
-## Examples
+## Example
 
-### Markdown file (default)
+### Example 1: Markdown file (default)
 
 If no other options are specified, files will be rendered as Markdown using the `RenderString` [function](https://gohugo.io/functions/renderstring/).
 
@@ -43,7 +42,7 @@ If you include markdown files that should not get a menu entry, place them outsi
 <!-- spellchecker-enable -->
 <!-- prettier-ignore-end -->
 
-### Language files
+### Example 2: Language files
 
 This method can be used to include source code files and keep them automatically up to date.
 
@@ -60,9 +59,7 @@ Result:
 <!-- spellchecker-enable -->
 <!-- prettier-ignore-end -->
 
-### Special include types
-
-#### HTML
+### Example 3: HTML
 
 HTML content will be filtered by the `safeHTML` filter and added to the rendered page output.
 
@@ -73,9 +70,9 @@ HTML content will be filtered by the `safeHTML` filter and added to the rendered
 
 {{< include file="/static/_includes/example.html.part" type="html" >}}
 
-#### Pages
+### Example 4: Hugo Pages
 
-In some situations, it can be helpful to include Markdown files that also contain shortcodes. While the [default method](#markdown-file-default) works fine to render plain Markdown, shortcodes are not parsed. The only way to get this to work is to use Hugo pages. There are several ways to structure these include pages, so whatever you do, keep in mind that Hugo needs to be able to render and serve these files as regular pages! How it works:
+In some situations, it can be helpful to include Markdown files that also contain shortcodes. While the [default method](#example-1-markdown-file-default) works fine to render plain Markdown, shortcodes are not parsed. The only way to get this to work is to use Hugo pages. There are several ways to structure these include pages, so whatever you do, keep in mind that Hugo needs to be able to render and serve these files as regular pages! How it works:
 
 1. First you need to create a directory **within** your content directory. For this example site `_includes` is used.
 2. To prevent the theme from embedding the page in the navigation, create a file `_includes/_index.md` and add `geekdocHidden: true` to the front matter.

--- a/exampleSite/content/en/shortcodes/katex.md
+++ b/exampleSite/content/en/shortcodes/katex.md
@@ -4,13 +4,23 @@ title: KaTeX
 
 [KaTeX](https://katex.org/) shortcode let you render math typesetting in markdown document.
 
-## Example
+## Usage
 
 ```latex
 {{</* katex [display] [class="text-center"] */>}}
 f(x) = \int_{-\infty}^\infty\hat f(\xi)\,e^{2 \pi i \xi x}\,d\xi
 {{</* /katex */>}}
 ```
+
+### Attributes
+
+<!-- prettier-ignore-start -->
+<!-- spellchecker-disable -->
+{{< propertylist name=shortcode-katex sort=name order=asc >}}
+<!-- spellchecker-enable -->
+<!-- prettier-ignore-end -->
+
+## Example
 
 <!-- spellchecker-disable -->
 <!-- prettier-ignore -->
@@ -20,4 +30,4 @@ f(x) = \int_{-\infty}^\infty\hat f(\xi)\,e^{2 \pi i \xi x}\,d\xi
 
 <!-- spellchecker-enable -->
 
-KaTeX can be used inline, for example {{< katex >}}\pi(x){{< /katex >}} or used with the `display` parameter (see above).
+KaTeX can be used inline, for example {{< katex >}}\pi(x){{< /katex >}} or used with the `display` parameter as above.

--- a/exampleSite/content/en/shortcodes/mermaid.md
+++ b/exampleSite/content/en/shortcodes/mermaid.md
@@ -4,7 +4,7 @@ title: Mermaid
 
 [Mermaid](https://mermaidjs.github.io/) is library for generating SVG charts and diagrams from text.
 
-## Example
+## Usage
 
 <!-- prettier-ignore -->
 ```tpl
@@ -21,6 +21,16 @@ sequenceDiagram
     end
 {{</* /mermaid */>}}
 ```
+
+### Attributes
+
+<!-- prettier-ignore-start -->
+<!-- spellchecker-disable -->
+{{< propertylist name=shortcode-mermaid sort=name order=asc >}}
+<!-- spellchecker-enable -->
+<!-- prettier-ignore-end -->
+
+## Example
 
 <!-- spellchecker-disable -->
 <!-- prettier-ignore -->

--- a/exampleSite/content/en/shortcodes/progress.md
+++ b/exampleSite/content/en/shortcodes/progress.md
@@ -4,20 +4,19 @@ title: Progress
 
 A progress bar shows how far a process has progressed.
 
-## Attributes
-
-| Name             | Description                                                                | default   |
-| ---------------- | -------------------------------------------------------------------------- | --------- |
-| value            | progress value                                                             | 0         |
-| icon (optional)  | icon to use, need to be an icon from an [SVG sprite](/features/icon-sets/) | undefined |
-| title (optional) | progress title                                                             | undefined |
-
 ## Usage
 
-<!-- prettier-ignore-start -->
+<!-- prettier-ignore -->
 ```tpl
 {{</* progress title=Eating value=65 icon=gdoc_heart */>}}
 ```
+
+### Attributes
+
+<!-- prettier-ignore-start -->
+<!-- spellchecker-disable -->
+{{< propertylist name=shortcode-progress sort=name order=asc >}}
+<!-- spellchecker-enable -->
 <!-- prettier-ignore-end -->
 
 ## Example

--- a/exampleSite/content/en/shortcodes/propertylist.md
+++ b/exampleSite/content/en/shortcodes/propertylist.md
@@ -4,14 +4,6 @@ title: Properties
 
 The property list shortcode creates a custom HTML description list that can be used to display properties or variables and general dependent information. The shortcode requires a data file in `data/properties/`, e.g. `data/properties/demo.yaml`.
 
-## Attributes
-
-| Name             | Description                                            | default   |
-| ---------------- | ------------------------------------------------------ | --------- |
-| name             | name of the file from the `data/properties/` directory | undefined |
-| sort (optional)  | field name to use for sorting                          | undefined |
-| order (optional) | sort order, only applied if `sort` is set              | `asc`     |
-
 ## Usage
 
 <!-- prettier-ignore-start -->
@@ -25,6 +17,14 @@ The supported attributes can be taken from the following example:
 <!-- prettier-ignore-start -->
 <!-- spellchecker-disable -->
 {{< include file="/data/properties/demo.yaml" language="Yaml" options="linenos=table" >}}
+<!-- spellchecker-enable -->
+<!-- prettier-ignore-end -->
+
+### Attributes
+
+<!-- prettier-ignore-start -->
+<!-- spellchecker-disable -->
+{{< propertylist name=shortcode-buttons sort=name order=asc >}}
 <!-- spellchecker-enable -->
 <!-- prettier-ignore-end -->
 

--- a/exampleSite/content/en/shortcodes/tabs.md
+++ b/exampleSite/content/en/shortcodes/tabs.md
@@ -4,6 +4,8 @@ title: Tabs
 
 Tabs let you organize content by context, for example installation instructions for each supported platform.
 
+## Usage
+
 <!-- prettier-ignore-start -->
 ```tpl
 {{</* tabs "uniqueid" */>}}

--- a/exampleSite/content/en/shortcodes/toc-tree.md
+++ b/exampleSite/content/en/shortcodes/toc-tree.md
@@ -4,6 +4,8 @@ title: ToC-Tree
 
 The `toc-tree` shortcode will generate a Table of Content from a section file tree of your content directory. The root of the resulting ToC will be the page on which you define the shortcode.
 
+## Usage
+
 <!-- prettier-ignore-start -->
 ```tpl
 {{</* toc-tree */>}}

--- a/exampleSite/content/en/shortcodes/toc.md
+++ b/exampleSite/content/en/shortcodes/toc.md
@@ -4,21 +4,22 @@ title: ToC
 
 Simple wrapper to generate a page Table of Content from a shortcode.
 
-**Attributes:**
+## Usage
 
-| Name   | Description                | Default                                                       |
-| ------ | -------------------------- | ------------------------------------------------------------- |
-| format | format of the returned ToC | <!-- spellchecker-disable -->html<!-- spellchecker-enable --> |
-
-**Usage:**
-
-<!-- prettier-ignore-start -->
+<!-- prettier-ignore -->
 ```tpl
 {{</* toc (format=[html|raw]) */>}}
 ```
+
+### Attributes
+
+<!-- prettier-ignore-start -->
+<!-- spellchecker-disable -->
+{{< propertylist name=shortcode-toc sort=name order=asc >}}
+<!-- spellchecker-enable -->
 <!-- prettier-ignore-end -->
 
-**Example:**
+## Example
 
 {{< toc >}}
 

--- a/exampleSite/data/properties/shortcode-buttons.yaml
+++ b/exampleSite/data/properties/shortcode-buttons.yaml
@@ -1,0 +1,19 @@
+---
+properties:
+  - name: href
+    type: string
+    description: The URL to use as target of the button.
+    required: false
+  - name: relref
+    type: string
+    description: Executes the [relref](https://gohugo.io/functions/urls/relref/) Hugo function to resolve the relative permalink of the specified page. The result is set as the target of the button.
+    required: false
+  - name: class
+    type: list
+    description: List of space-separated CSS class names to apply.
+    required: false
+  - name: size
+    type: string
+    description: Preset of different button sizes. Supported values are `regular|large`.
+    required: false
+    devaultValue: regular

--- a/exampleSite/data/properties/shortcode-columns.yaml
+++ b/exampleSite/data/properties/shortcode-columns.yaml
@@ -1,0 +1,7 @@
+---
+properties:
+  - name: size
+    type: string
+    description: Preset of different sizes for the _first_ column. Supported values are `small|regular|large`.
+    required: false
+    defaultValue: regular

--- a/exampleSite/data/properties/shortcode-hints.yaml
+++ b/exampleSite/data/properties/shortcode-hints.yaml
@@ -1,0 +1,15 @@
+---
+properties:
+  - name: type
+    type: string
+    description: Type of the hint. Supported values are `note|tip|important|caution|warning`.
+    required: false
+    defaultValue: note
+  - name: icon
+    type: string
+    description: Icon to use. The value need to be an icon from an [SVG sprite](/features/icon-sets/).
+    required: false
+  - name: title
+    type: string
+    description: Title text of the hint.
+    required: false

--- a/exampleSite/data/properties/shortcode-images.yaml
+++ b/exampleSite/data/properties/shortcode-images.yaml
@@ -1,0 +1,19 @@
+---
+properties:
+  - name: name
+    type: string
+    description: Mame of the image resource defined in page front matter.
+    required: true
+  - name: alt
+    type: string
+    description: Description text for the image.
+    required: false
+  - name: size
+    type: string
+    description: Thumbnail size. Supported values are `origin|profile|tiny|small|medium|large`.
+    required: false
+  - name: lazy
+    type: bool
+    description: Enable/disable lazy loading for the image.
+    required: false
+    defaultValue: true

--- a/exampleSite/data/properties/shortcode-includes.yaml
+++ b/exampleSite/data/properties/shortcode-includes.yaml
@@ -1,0 +1,19 @@
+---
+properties:
+  - name: file
+    type: string
+    description: Path of the file (relative to the Hugo root) to include.
+    required: true
+  - name: language
+    type: string
+    description: Language for [syntax highlighting](https://gohugo.io/content-management/syntax-highlighting/#list-of-chroma-highlighting-languages).
+    required: false
+  - name: type
+    type: string
+    description: Special include type. Supported values are `html|page`. If not set the included file is rendered as markdown.
+    required: false
+  - name: options
+    type: bool
+    description: highlighting [options](https://gohugo.io/content-management/syntax-highlighting/#highlight-shortcode).
+    required: false
+    defaultValue: linenos=table

--- a/exampleSite/data/properties/shortcode-katex.yaml
+++ b/exampleSite/data/properties/shortcode-katex.yaml
@@ -1,0 +1,6 @@
+---
+properties:
+  - name: class
+    type: list
+    description: List of space-separated CSS class names to apply.
+    required: false

--- a/exampleSite/data/properties/shortcode-mermaid.yaml
+++ b/exampleSite/data/properties/shortcode-mermaid.yaml
@@ -1,0 +1,6 @@
+---
+properties:
+  - name: class
+    type: list
+    description: List of space-separated CSS class names to apply.
+    required: false

--- a/exampleSite/data/properties/shortcode-progress.yaml
+++ b/exampleSite/data/properties/shortcode-progress.yaml
@@ -1,0 +1,15 @@
+---
+properties:
+  - name: value
+    type: integer
+    description: Progress value.
+    required: false
+    defaultValue: 0
+  - name: icon
+    type: string
+    description: Icon to use. The value need to be an icon from an [SVG sprite](/features/icon-sets/).
+    required: false
+  - name: title
+    type: string
+    description: Title text of the progress bar.
+    required: false

--- a/exampleSite/data/properties/shortcode-propertylist.yaml
+++ b/exampleSite/data/properties/shortcode-propertylist.yaml
@@ -1,0 +1,15 @@
+---
+properties:
+  - name: name
+    type: string
+    description: Name of the file from the `data/properties/` directory.
+    required: true
+  - name: sort
+    type: string
+    description: Field name to use for sorting.
+    required: false
+  - name: order
+    type: string
+    description: Sort order, only applied if `sort` is set. Supported values are `asc|desc`.
+    required: false
+    defaultValue: asc

--- a/exampleSite/data/properties/shortcode-toc.yaml
+++ b/exampleSite/data/properties/shortcode-toc.yaml
@@ -1,0 +1,10 @@
+---
+properties:
+  - name: format
+    type: string
+    description: |
+      Format of the returned ToC. The `html` format creates an HTML wrapper to enable the `geekdocToC` parameter that limits
+      the maximum ToC level to be displayed. This variant also automatically inserts a horizontal line after the ToC. The `raw` format
+      returns the unformatted ToC, the parameter `geekdocToC` does not work in this mode. Supported values are `html|raw`.
+    required: false
+    defaultValue: html


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/hugo-geekdoc/issues/731