### PR TITLE
fix: fix missing icon on collabsible bundle menus

### DIFF
--- a/layouts/partials/menu-bundle.html
+++ b/layouts/partials/menu-bundle.html
@@ -68,7 +68,7 @@
                 <svg class="gdoc-icon toggle gdoc_keyboard_arrow_left">
                   <use xlink:href="#gdoc_keyboard_arrow_left"></use>
                 </svg>
-                <svg class="gdoc-icon toggle gdoc_keyboard_arrow_down hidden">
+                <svg class="gdoc-icon toggle gdoc_keyboard_arrow_down">
                   <use xlink:href="#gdoc_keyboard_arrow_down"></use>
                 </svg>
               {{ end }}


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/hugo-geekdoc/issues/737