### PR TITLE
docs: explain `buildDrafts` flag in getting started guide

### DIFF
--- a/exampleSite/content/en/usage/getting-started.md
+++ b/exampleSite/content/en/usage/getting-started.md
@@ -80,6 +80,8 @@ To prepare your new site environment just a few steps are required:
    hugo server -D
    ```
 
+   The `-D` or `--buildDrafts` option is used to include content marked as draft during the build. It is used because content pages created with the `hugo new content` command have the `draft` flag set by default and this can lead to build errors in newly created projects. For projects with a production-ready content structure, this flag is not required in most cases and can be omitted.
+
 ### Option 1: Download pre-build release bundle
 
 Download and extract the latest release bundle into the theme directory.


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/hugo-geekdoc/issues/784