### PR TITLE
docs: add information that `unsafe = true` is required for nested shortcodes

### DIFF
--- a/exampleSite/content/en/usage/configuration.md
+++ b/exampleSite/content/en/usage/configuration.md
@@ -26,7 +26,8 @@ enableRobotsTXT = true
 
 [markup]
   [markup.goldmark.renderer]
-    # Needed for mermaid shortcode
+    # Needed for mermaid shortcode or when nesting shortcodes (e.g. img within
+    # columns or tabs)
     unsafe = true
   [markup.tableOfContents]
     startLevel = 1
@@ -150,7 +151,8 @@ enableRobotsTXT: true
 
 markup:
   goldmark:
-    # Needed for mermaid shortcode
+    # Needed for mermaid shortcode or when nesting shortcodes (e.g. img within
+    # columns or tabs)
     renderer:
       unsafe: true
   tableOfContents:

--- a/exampleSite/content/en/usage/getting-started.md
+++ b/exampleSite/content/en/usage/getting-started.md
@@ -64,7 +64,8 @@ To prepare your new site environment just a few steps are required:
    # Needed for mermaid shortcodes
    [markup]
      [markup.goldmark.renderer]
-       # Needed for mermaid shortcode
+       # Needed for mermaid shortcode or when nesting shortcodes (e.g. img within
+       # columns or tabs)
        unsafe = true
      [markup.tableOfContents]
        startLevel = 1


### PR DESCRIPTION
Here's the suggested documentation improvement for the issue I created a few days ago (#791). I only extended the comments in the config file examples as for me this would have been sufficient. Let me know if you think more is needed.