### PR TITLE
fix: skip image processing if size is origin

### DIFF
--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -8,7 +8,7 @@
   {{- $caption := default .Title $customAlt }}
   {{- $isSVG := (eq .MediaType.SubType "svg") }}
 
-  {{- $origin := .Permalink }}
+  {{- $origin := . }}
   {{- if $isSVG }}
     {{- $data.SetInMap "size" "profile" "180" }}
     {{- $data.SetInMap "size" "tiny" "320" }}
@@ -16,40 +16,46 @@
     {{- $data.SetInMap "size" "medium" "1200" }}
     {{- $data.SetInMap "size" "large" "1800" }}
   {{- else }}
-    {{- $data.SetInMap "size" "profile" (.Fill "180x180 Center").Permalink }}
-    {{- $data.SetInMap "size" "tiny" (.Resize "320x").Permalink }}
-    {{- $data.SetInMap "size" "small" (.Resize "600x").Permalink }}
-    {{- $data.SetInMap "size" "medium" (.Resize "1200x").Permalink }}
-    {{- $data.SetInMap "size" "large" (.Resize "1800x").Permalink }}
+    {{- $data.SetInMap "size" "profile" "180x180 Center" }}
+    {{- $data.SetInMap "size" "tiny" "320x"}}
+    {{- $data.SetInMap "size" "small" "600x" }}
+    {{- $data.SetInMap "size" "medium" "1200x" }}
+    {{- $data.SetInMap "size" "large" "1800x" }}
   {{- end }}
 
 
   <div class="flex justify-center">
     <figure
       class="gdoc-markdown__figure
-      {{- if eq $customSize "profile" }}{{ print " gdoc-post__figure--round" }}{{ end }}"
+      {{- if eq $customSize "profile" }}{{ print " gdoc-markdown__figure--round" }}{{ end }}"
     >
       <a class="gdoc-markdown__link--raw" href="{{ .Permalink }}">
         <picture>
           {{- $size := $data.Get "size" }}
           {{- if not $isSVG }}
+            {{- if ne $customSize "origin" }}
             <source
               {{- with $customSize }}
-                srcset="{{ index $size $customSize }}"
+                {{- if eq $customSize "profile" }}
+                srcset="{{ ($origin.Fill (index $size $customSize)).Permalink }}"
+                {{- else}}
+                srcset="{{ ($origin.Resize (index $size $customSize)).Permalink }}"
+                {{- end}}
               {{- else }}
-                srcset="{{ $size.small }} 600w, {{ $size.medium }} 1200w" sizes="100vw"
+                srcset="{{ ($origin.Resize (index $size "small")).Permalink }} 600w, {{ ($origin.Resize (index $size "medium")).Permalink }} 1200w" sizes="100vw"
               {{- end }}
             />
+            {{- end }}
           {{- end }}
           <img
             {{- if $isSVG }}
-              src="{{ $origin }}" width="{{ index $size (default "medium" $customSize) }}"
+              src="{{ $origin.Permalink }}" width="{{ index $size (default "medium" $customSize) }}"
             {{- else }}
               {{- if $lazyLoad }}{{ print " loading=\"lazy\"" | safeHTMLAttr }}{{- end }}
               {{- if eq $customSize "origin" }}
-                src="{{ $origin }}"
+                src="{{ $origin.Permalink }}"
               {{- else }}
-                src="{{ $size.large }}"
+                src="{{ ($origin.Resize (index $size "large")).Permalink }}"
               {{- end }}
               alt="{{ $caption }}"
             {{- end }}


### PR DESCRIPTION
The image shortcode as still preprocessed all image resources even if the size was set to `origin` which results in unintentional long build times.

Fixes: https://github.com/thegeeklab/hugo-geekdoc/issues/816