### PR TITLE
fix: replace deprecated `.Site.IsMultiLingual` and `.Site.Social`

### DIFF
--- a/layouts/partials/language.html
+++ b/layouts/partials/language.html
@@ -1,4 +1,4 @@
-{{ if .Site.IsMultiLingual }}
+{{ if hugo.IsMultilingual }}
   <span class="gdoc-language">
     <ul class="gdoc-language__selector" role="button" aria-pressed="false" tabindex="0">
       <li>

--- a/layouts/partials/microformats/opengraph.html
+++ b/layouts/partials/microformats/opengraph.html
@@ -63,6 +63,6 @@
 {{- end }}
 
 {{- /* Facebook Page Admin ID for Domain Insights */}}
-{{- with .Site.Social.facebook_admin }}
+{{- with .Site.Params.facebook_admin }}
   <meta property="fb:admins" content="{{ . }}" />
 {{- end }}

--- a/layouts/partials/microformats/twitter_cards.html
+++ b/layouts/partials/microformats/twitter_cards.html
@@ -10,6 +10,6 @@
 {{- with partial "utils/description" . }}
   <meta name="twitter:description" content="{{ . | plainify | htmlUnescape | chomp }}" />
 {{- end }}
-{{- with .Site.Social.twitter -}}
+{{- with .Site.Params.twitter -}}
   <meta name="twitter:site" content="@{{ . }}" />
 {{- end }}


### PR DESCRIPTION
With newer versions of Hugo, we get the following warning messages
> WARN  deprecated: .Site.IsMultiLingual was deprecated in Hugo v0.124.0 and will be removed in a future release. Use hugo.IsMultilingual instead.
WARN  deprecated: .Site.Social was deprecated in Hugo v0.124.0 and will be removed in a future release. Use .Site.Params instead.


**More information**: 
- https://github.com/gohugoio/hugo/issues/12224 
- https://gohugo.io/methods/site/ismultilingual/
- https://github.com/gohugoio/hugo/issues/12228