### PR TITLE
feat: add parameter geekdocPageLastmod

### DIFF
--- a/exampleSite/config/_default/params.yaml
+++ b/exampleSite/config/_default/params.yaml
@@ -11,6 +11,7 @@ geekdocTagsToMenu: true
 
 geekdocRepo: https://github.com/thegeeklab/hugo-geekdoc
 geekdocEditPath: edit/main/exampleSite
+geekdocPageLastmod: false
 
 geekdocSearch: true
 geekdocSearchShowParent: true

--- a/exampleSite/content/en/usage/configuration.md
+++ b/exampleSite/content/en/usage/configuration.md
@@ -70,6 +70,10 @@ enableRobotsTXT = true
   # You can also specify this parameter per page in front matter.
   geekdocEditPath = "edit/main/exampleSite"
 
+  # (Optional, default false) Show last modification date of the page in the header.
+  # Keep in mind that last modification date works best if `enableGitInfo` is set to true.
+  geekdocPageLastmod = true
+
   # (Optional, default true) Enables search function with flexsearch.
   # Index is built on the fly and might slow down your website.
   geekdocSearch = false
@@ -196,6 +200,10 @@ params:
   # You can also specify this parameter per page in front matter.
   geekdocEditPath: edit/main/exampleSite
 
+  # (Optional, default false) Show last modification date of the page in the header.
+  # Keep in mind that last modification date works best if `enableGitInfo` is set to true.
+  geekdocPageLastmod: true
+
   # (Optional, default true) Enables search function with flexsearch.
   # Index is built on the fly and might slow down your website.
   geekdocSearch: false
@@ -294,6 +302,9 @@ geekdocRepo = "https://github.com/thegeeklab/hugo-geekdoc"
 # the parent directory of the 'content' folder.
 geekdocEditPath = "edit/main/exampleSite"
 
+# Show last modification date of the page in the header.
+geekdocPageLastmod = true
+
 # Used for 'Edit page' link, set to '.File.Path' by default.
 # Can be overwritten by a path relative to 'geekdocEditPath'
 geekdocFilePath =
@@ -353,6 +364,9 @@ geekdocRepo: "https://github.com/thegeeklab/hugo-geekdoc"
 # Enable 'Edit page' links. Requires 'geekdocRepo' param and the path must point to
 # the parent directory of the 'content' folder.
 geekdocEditPath: "edit/main/exampleSite"
+
+# Show last modification date of the page in the header.
+geekdocPageLastmod: true
 
 # Used for 'Edit page' link, set to '.File.Path' by default.
 # Can be overwritten by a path relative to 'geekdocEditPath'

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,6 +6,7 @@
     class="gdoc-markdown gdoc-markdown__align--{{ default "left" (.Page.Params.geekdocAlign | lower) }}"
   >
     <h1>{{ partial "utils/title" . }}</h1>
+    {{ partial "page-metadata" . }}
     {{ partial "utils/content" . }}
   </article>
 {{ end }}

--- a/layouts/partials/page-metadata.html
+++ b/layouts/partials/page-metadata.html
@@ -1,0 +1,13 @@
+{{- $showPageLastmod := (or (default false .Page.Params.geekdocPageLastmod) (default false .Site.Params.geekdocPageLastmod)) -}}
+
+{{- if $showPageLastmod -}}
+<span class="flex align-center no-wrap">
+    <svg class="gdoc-icon gdoc_date"><use xlink:href="#gdoc_date"></use></svg>
+    <time datetime="{{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}">
+        {{ if .Lastmod.After (.Date.AddDate 0 0 1) }}
+        {{ i18n "posts_update_prefix" }}
+        {{ end }}
+        {{ .Lastmod.Format "Jan 2, 2006" }}
+    </time>
+</span>
+{{- end -}}


### PR DESCRIPTION
Add new site- and page-parameter `geekdocPageLastmod` to show last modification date on the page header. The PR also add a partial `page-metadata` that can be overwritten to easily add custom page metadata.

Fixes: https://github.com/thegeeklab/hugo-geekdoc/issues/894