### PR TITLE
Search: Use relative URLs within generated configuration and data files

### DIFF
--- a/assets/search/config.json
+++ b/assets/search/config.json
@@ -1,7 +1,7 @@
 {{- $searchDataFile := printf "search/%s.data.json" .Language.Lang -}}
 {{- $searchData := resources.Get "search/data.json" | resources.ExecuteAsTemplate $searchDataFile . | resources.Minify -}}
 {
-  "dataFile": {{ $searchData.RelPermalink | jsonify }},
+  "dataFile": {{ printf ".%s" $searchData.RelPermalink | jsonify }},
   "indexConfig": {{ .Site.Params.geekdocSearchConfig | jsonify }},
   "showParent": {{ if .Site.Params.geekdocSearchShowParent }}true{{ else }}false{{ end }},
   "showDescription": {{ if .Site.Params.geekdocSearchshowDescription }}true{{ else }}false{{ end }}

--- a/assets/search/data.json
+++ b/assets/search/data.json
@@ -3,7 +3,7 @@
     {{ if ne $index 0 }},{{ end }}
     {
       "id": {{ $index }},
-      "href": "{{ $page.RelPermalink }}",
+      "href": ".{{ $page.RelPermalink }}",
       "title": {{ (partial "utils/title" $page) | jsonify }},
       "parent": {{ with $page.Parent }}{{ (partial "utils/title" .) | jsonify }}{{ else }}""{{ end }},
       "content": {{ $page.Plain | jsonify }},


### PR DESCRIPTION
Always use relative URLs when generating the configuration and data file for the search bar.
This fixes issues with deployments that run under a sub-path, e.g. https://example.com/path.

Fixes #963.

Any help or comments about possible improvements of this PR is highly appreciated.