### PR TITLE
fix: use site param geekdocLogo in microformats

### DIFF
--- a/layouts/partials/microformats/schema.html
+++ b/layouts/partials/microformats/schema.html
@@ -60,7 +60,7 @@
           "url": {{ .Site.Home.Permalink }},
           "logo": {
               "@type": "ImageObject",
-              "url": {{ (default "brand.svg" .Site.Params.logo) | absURL }},
+              "url": {{ (default "brand.svg" .Site.Params.geekdocLogo) | absURL }},
               "width":"32",
               "height":"32"
           }


### PR DESCRIPTION
I stumbled over this bug by reading the error message in https://github.com/thegeeklab/hugo-geekdoc/issues/1001. 