### PR TITLE
Add rel=edit attribute to "Edit page" link

### DIFF
--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -48,6 +48,7 @@
         <svg class="gdoc-icon gdoc_code"><use xlink:href="#gdoc_code"></use></svg>
         <a
           href="{{ $geekdocRepo }}/{{ path.Join $geekdocEditPath ($.Scratch.Get "geekdocFilePath") }}"
+          rel="edit"
         >
           {{ i18n "edit_page" }}
         </a>


### PR DESCRIPTION
This PR adds the `rel="edit"` attribute to the "Edit page" edit link.

rel=edit lets a page indicate that the linked resource can be used to edit the page. It is defined at https://microformats.org/wiki/rel-edit. This can then be parsed by tools like the Universal Edit Button and custom bookmarklets to open the edit page corresponding with a website.