### PR TITLE
feat: support raw delimiters in markdown for katex

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -7,3 +7,5 @@ MD004:
   style: dash
 MD010:
   code_blocks: False
+MD024:
+  siblings_only: True

--- a/exampleSite/config/_default/hugo.yaml
+++ b/exampleSite/config/_default/hugo.yaml
@@ -19,6 +19,15 @@ markup:
   goldmark:
     renderer:
       unsafe: true
+    extensions:
+      passthrough:
+        enable: true
+        delimiters:
+          block:
+            - ["$$", "$$"]
+            - ["\\[", "\\]"]
+          inline:
+            - ["\\(", "\\)"]
   tableOfContents:
     startLevel: 1
     endLevel: 9

--- a/exampleSite/content/en/shortcodes/katex.md
+++ b/exampleSite/content/en/shortcodes/katex.md
@@ -1,16 +1,25 @@
 ---
 title: KaTeX
+geekdocMath: true
 # cspell:ignore infty
 ---
 
-[KaTeX](https://katex.org/) shortcode let you render math typesetting in markdown document.
+The [KaTeX](https://katex.org/) integration lets you render math typesetting in markdown documents. The theme supports two ways to write math: the `katex` shortcode and `$$...$$` / `\(...\)` delimiters.
 
-## Usage
+## Enabling KaTeX
+
+To use raw `$$...$$` or `\(...\)` delimiters in your content, set `geekdocMath: true` either site-wide in the params config or per-page in the front matter. When enabled, the KaTeX assets are loaded in the page `<head>`. The `katex` shortcode does not require this flag, it lazy-loads the assets on first use, so it works on any page out of the box.
+
+## Shortcode
+
+Use the shortcode for inline or display math. The content between the opening and closing tags is rendered as a LaTeX expression. By default the expression is rendered inline (flowing with surrounding text using `\(...\)` delimiters). Pass the `display` flag to render it as display math instead (block-level, centered, on its own line using `\[...\]` delimiters).
 
 ```latex
-{{</* katex [display] [class="text-center"] */>}}
+{{</* katex display [class="text-center"] */>}}
 f(x) = \int_{-\infty}^\infty\hat f(\xi)\,e^{2 \pi i \xi x}\,d\xi
 {{</* /katex */>}}
+
+KaTeX can be used inline, for example {{</* katex */>}}\pi(x){{</* /katex */>}}, or as display math with the `display` parameter as shown above.
 ```
 
 ### Attributes
@@ -21,7 +30,7 @@ f(x) = \int_{-\infty}^\infty\hat f(\xi)\,e^{2 \pi i \xi x}\,d\xi
 <!-- cspell:enable -->
 <!-- prettier-ignore-end -->
 
-## Example
+### Example
 
 <!-- cspell:disable -->
 <!-- prettier-ignore -->
@@ -29,6 +38,47 @@ f(x) = \int_{-\infty}^\infty\hat f(\xi)\,e^{2 \pi i \xi x}\,d\xi
 f(x) = \int_{-\infty}^\infty\hat f(\xi)\,e^{2 \pi i \xi x}\,d\xi
 {{< /katex >}}
 
+KaTeX can be used inline, for example {{< katex >}}\pi(x){{< /katex >}}, or as display math with the `display` parameter as shown above.
 <!-- cspell:enable -->
 
-KaTeX can be used inline, for example {{< katex >}}\pi(x){{< /katex >}} or used with the `display` parameter as above.
+## Delimiters
+
+When math is enabled, expressions wrapped in `$$...$$` are auto-rendered as display math (block-level), and expressions wrapped in `\(...\)` are auto-rendered as inline math.
+
+````markdown
+$$
+f(x) = \int_{-\infty}^\infty\hat f(\xi)\,e^{2 \pi i \xi x}\,d\xi
+$$
+
+KaTeX can be used inline, for example \(\pi(x)\), or as display math with `$$...$$` as shown above.
+````
+
+The theme intentionally uses `\(...\)` for inline math instead of the more common `$...$` to avoid collisions with literal dollar signs in prose (for example `it costs $5 to $10` would otherwise be interpreted as math). Content inside fenced code blocks and inline code spans is left untouched.
+
+To prevent Goldmark from interpreting the LaTeX source as Markdown, configure the [passthrough extension][passthrough] in your Hugo config so the delimited content is forwarded to KaTeX untouched:
+
+```yaml
+markup:
+  goldmark:
+    extensions:
+      passthrough:
+        enable: true
+        delimiters:
+          block:
+            - ["$$", "$$"]
+            - ["\\[", "\\]"]
+          inline:
+            - ["\\(", "\\)"]
+```
+
+[passthrough]: https://gohugo.io/configuration/markup/#passthrough
+
+### Example
+
+<!-- cspell:disable -->
+$$
+f(x) = \int_{-\infty}^\infty\hat f(\xi)\,e^{2 \pi i \xi x}\,d\xi
+$$
+
+KaTeX can be used inline, for example \(\pi(x)\), or as display math with `$$...$$` as shown above.
+<!-- cspell:enable -->

--- a/exampleSite/data/properties/shortcode-katex.yaml
+++ b/exampleSite/data/properties/shortcode-katex.yaml
@@ -4,3 +4,9 @@ properties:
     type: list
     description: List of space-separated CSS class names to apply.
     required: false
+  - name: display
+    type: flag
+    description: >
+      Render the expression as display math (block-level, centered, on its own
+      line) instead of inline math.
+    required: false

--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -2,8 +2,8 @@
 {{ if not (.Page.Scratch.Get "mermaid") }}
   <!-- Include mermaid only first time -->
   <script defer src="{{ index (index hugo.Data.assets "mermaid.js") "src" | relURL }}"></script>
-  {{ .Page.Scratch.Set "mermaid" true }}
 {{ end }}
+{{ .Page.Scratch.Set "mermaid" true }}
 <!-- prettier-ignore-end -->
 
 <pre class="gdoc-mermaid mermaid text-center">

--- a/layouts/partials/head/others.html
+++ b/layouts/partials/head/others.html
@@ -3,6 +3,14 @@
 {{- end }}
 <script src="{{ index (index hugo.Data.assets "main.js") "src" | relURL }}"></script>
 
+{{- if .Page.Param "geekdocMath" }}
+  <link
+    rel="stylesheet"
+    href="{{ index (index hugo.Data.assets "katex.css") "src" | relURL }}"
+  />
+  <script defer src="{{ index (index hugo.Data.assets "katex.js") "src" | relURL }}"></script>
+{{- end }}
+
 <link
   rel="preload"
   as="font"

--- a/layouts/shortcodes/katex.html
+++ b/layouts/shortcodes/katex.html
@@ -1,13 +1,13 @@
 <!-- prettier-ignore-start -->
-{{ if not (.Page.Scratch.Get "katex") }}
-  <!-- Include katex only first time -->
+{{ if and (not (.Page.Scratch.Get "katex")) (not (.Page.Param "geekdocMath")) }}
+  <!-- Include KaTeX assets only on first shortcode use, unless already loaded globally via geekdocMath -->
   <link
     rel="stylesheet"
     href="{{ index (index hugo.Data.assets "katex.css") "src" | relURL }}"
   />
   <script defer src="{{ index (index hugo.Data.assets "katex.js") "src" | relURL }}"></script>
-  {{ .Page.Scratch.Set "katex" true }}
 {{ end }}
+{{ .Page.Scratch.Set "katex" true }}
 <!-- prettier-ignore-end -->
 
 <span class="gdoc-katex {{ with .Get "class" }}{{ . }}{{ end }}">

--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -2,8 +2,8 @@
 {{ if not (.Page.Scratch.Get "mermaid") }}
   <!-- Include mermaid only first time -->
   <script defer src="{{ index (index hugo.Data.assets "mermaid.js") "src" | relURL }}"></script>
-  {{ .Page.Scratch.Set "mermaid" true }}
 {{ end }}
+{{ .Page.Scratch.Set "mermaid" true }}
 <!-- prettier-ignore-end -->
 
 <pre class="gdoc-mermaid mermaid{{ with .Get "class" }}{{ printf " %s" . }}{{ end }}">

--- a/src/js/katex.js
+++ b/src/js/katex.js
@@ -1,4 +1,14 @@
 import "katex/dist/katex.css"
 import renderMathInElement from "katex/dist/contrib/auto-render.mjs"
 
-renderMathInElement(document.body)
+document.addEventListener("DOMContentLoaded", () => {
+  renderMathInElement(document.body, {
+    delimiters: [
+      { left: "$$", right: "$$", display: true },
+      { left: "\\[", right: "\\]", display: true },
+      { left: "\\(", right: "\\)", display: false }
+    ],
+    ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code", "option"],
+    throwOnError: false
+  })
+})


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/hugo-geekdoc/issues/859