### PR TITLE
docs: add search config example

### DIFF
--- a/exampleSite/content/en/usage/configuration.md
+++ b/exampleSite/content/en/usage/configuration.md
@@ -87,6 +87,10 @@ enableRobotsTXT = true
   # NOTE: This parameter only applies when 'geekdocSearch = true'.
   geekdocSearchShowParent = true
 
+  # (Optional, default none) Configure the flexsearch index. This replaces the
+  # default index config, so include all options you want to keep.
+  geekdocSearchConfig = { tokenize = "forward", encoder = "Normalize" }
+
   # (Optional, default none) Add a link to your Legal Notice page to the site footer.
   # It can be either a remote url or a local file path relative to your content directory.
   geekdocLegalNotice = "https://blog.example.com/legal"
@@ -219,6 +223,12 @@ params:
   # option allows you to distinguish between files with the same name in different folders.
   # NOTE: This parameter only applies when 'geekdocSearch: true'.
   geekdocSearchShowParent: true
+
+  # (Optional, default none) Configure the flexsearch index. This replaces the
+  # default index config, so include all options you want to keep.
+  geekdocSearchConfig:
+    tokenize: forward
+    encoder: Normalize
 
   # (Optional, default none) Add a link to your Legal Notice page to the site footer.
   # It can be either a remote url or a local file path relative to your content directory.


### PR DESCRIPTION
## Summary

Adds a `geekdocSearchConfig` example to the configuration docs.

## Related Issue

Fixes #1000

## Changes

- Shows the search config option in both TOML and YAML examples.
- Notes that a custom search config replaces the default index config.

## Testing

- [x] `docker run --rm -v "$PWD":/src -w /src node:24.15.0 npm ci`
- [x] `docker run --rm -v "$PWD":/src -w /src node:24.15.0 npm run build`
- [x] `docker run --rm -v "$PWD":/src -w /src node:24.15.0 npm run lint:js`
- [x] `docker run --rm --user root --entrypoint sh -v "$PWD":/src -w /src ghcr.io/gohugoio/hugo:v0.163.0 -lc 'apk add --no-cache asciidoctor >/dev/null && git config --global --add safe.directory /src && hugo --minify --gc -s exampleSite'`

## Notes

The host Node version was `v22.22.0`, while one dependency requires at least `v22.22.2`, so validation was run in Docker with Node `24.15.0`.
