### PR TITLE
fix: wrap long unbreakable links in markdown content

### DIFF
--- a/src/sass/_markdown.scss
+++ b/src/sass/_markdown.scss
@@ -36,6 +36,7 @@
     text-decoration: underline;
     border-bottom: defaults.$border-1 solid transparent;
     line-height: normal;
+    overflow-wrap: anywhere;
 
     &:hover {
       text-decoration: none;


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/hugo-geekdoc/issues/1253